### PR TITLE
Fix svg layout

### DIFF
--- a/docker/app-state-diagram/Dockerfile
+++ b/docker/app-state-diagram/Dockerfile
@@ -3,6 +3,8 @@ FROM php:alpine
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN apk --no-cache upgrade \
+ && apk --no-cache add ttf-linux-libertine \
+ && fc-cache -f \
  && apk --no-cache add graphviz nodejs npm
 
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer global require koriym/app-state-diagram \

--- a/docker/asd-action/Dockerfile
+++ b/docker/asd-action/Dockerfile
@@ -3,7 +3,8 @@ FROM php:alpine
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN apk upgrade --no-cache \
- && apk add --no-cache graphviz \
+ && apk add --no-cache graphviz ttf-linux-libertine \
+ && fc-cache -f \
  && COMPOSER_ALLOW_SUPERUSER=1 composer require koriym/app-state-diagram
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
In the existing container image, Times-Roman font is not installed.

```
$ docker run -v "$(pwd):/work" -it --init --rm ghcr.io/alps-asd/app-state-diagram dot -Tsvg -v -o/work/profile.svg /work/profile.dot
dot - graphviz version 2.47.1 (20210515.0534)
libdir = "/usr/lib/graphviz"
Activated plugin library: libgvplugin_core.so.6
Using render: svg:core
Using device: svg:svg:core
Activated plugin library: libgvplugin_dot_layout.so.6
Using layout: dot:dot_layout
The plugin configuration file:
        /usr/lib/graphviz/config6
                was successfully loaded.
    render      :  cairo dot dot_json fig json json0 map mp pic pov ps svg tk visio vml xdot xdot_json
    layout      :  circo dot fdp neato nop nop1 nop2 osage patchwork sfdp twopi
    textlayout  :  textlayout
    device      :  canon cmap cmapx cmapx_np dot dot_json eps fig gv imap imap_np ismap json json0 mp pdf pic plain plain-ext png pov ps ps2 svg svgz tk vdx vml vmlz x11 xdot xdot1.2 xdot1.4 xdot_json xlib
    loadimage   :  (lib) eps gif jpe jpeg jpg png ps svg
fontname: unable to resolve "Helvetica"
pack info:
  mode   undefined
  size   0
  flags  0
  margin 8
pack info:
  mode   node
  size   0
  flags  0
fontname: unable to resolve "Times-Roman"
network simplex:  4 nodes 3 edges maxiter=2147483647 balance=1
network simplex: 4 nodes 3 edges 0 iter 0.00 sec
Maxrank = 4, minrank = 0
mincross: pass 0 iter 0 trying 0 cur_cross 0 best_cross 0
mincross application_state_diagram: 0 crossings, 0.00 secs.
network simplex:  19 nodes 24 edges maxiter=2147483647 balance=2
network simplex: 19 nodes 24 edges 3 iter 0.00 sec
routesplines: 5 edges, 25 boxes 0.00 sec
Using render: svg:core
Using device: svg:svg:core
gvRenderJobs application_state_diagram: 0.00 secs.
```

check current container's output

```
docker/app-state-diagram/build.sh
docker/app-state-diagram/run.sh
```

see https://gitlab.com/graphviz/graphviz/-/issues/1426