### PR TITLE
style: improve diagram-mode styles #166

### DIFF
--- a/src/DumpDocs.php
+++ b/src/DumpDocs.php
@@ -84,15 +84,65 @@ EOT;
     private function dumpImageHtml(string $title, string $docsDir, string $imgSrc, string $type): void
     {
         $isIdMode = $type === '';
-        $link = $isIdMode ? 'id | <a href="asd.title.html">title</a>' : '<a href="asd.html">id</a> | title';
+        $link = $isIdMode ? '<ul class="diagram-mode"> <li class="diagram-mode__item"> <span class="diagram-mode__text">id</span> </li><li class="diagram-mode__item"> <a href="asd.title.html" class="diagram-mode__link">title</a> </li></ul>' : '<ul class="diagram-mode"> <li class="diagram-mode__item"> <a href="asd.html" class="diagram-mode__link">id</a> </li><li class="diagram-mode__item"> <span class="diagram-mode__text">title</span> </li></ul>';
         $html = <<<EOT
 <html lang="en">
 <head>
     <title>{$title}</title>
     <meta charset="UTF-8">
+    <style>
+      :root {
+        --color-text-base: #24292e;
+        --color-border-base: #eaecef;
+        --color-link-base: #3366cc;
+        --font-size-base: 1rem;
+      }
+
+      .diagram-mode {
+        margin-block-end: 2rem;
+        border-bottom: 1px solid var(--color-border-base);
+        font-size: var(--font-size-base);
+      }
+
+      .diagram-mode__item {
+        display: inline-flex;
+        margin-inline: 0.5rem;
+        list-style: none;
+        color: var(--color-text-base);
+      }
+
+      .diagram-mode__text {
+        display: inline-flex;
+        position: relative;
+        box-sizing: border-box;
+        max-height: 4em;
+        margin-block-end: -1px;
+        padding-block: 1.5rem 0.5rem;
+        border-bottom: 1px solid;
+        text-decoration: none;
+        color: var(--color-text-base);
+      }
+
+      .diagram-mode__link {
+        display: inline-flex;
+        position: relative;
+        box-sizing: border-box;
+        max-height: 4em;
+        margin-block-end: -1px;
+        padding-block: 1.5rem 0.5rem;
+        cursor: pointer;
+        color: var(--color-link-base);
+        text-decoration: none;
+      }
+
+      .diagram-mode__link:hover,
+      .diagram-mode__link:focus {
+        border-bottom: 1px solid;
+      }
+    </style>
 </head>
 <body>
-    <div style="font-size: medium;" >{$link}</div>
+    <div>{$link}</div>
     <iframe src="../{$imgSrc}" style="border:0; width:100%; height:95%" allow="fullscreen"></iframe>
 </body>
 </html>


### PR DESCRIPTION
## 概要

ASDの `id` `title` モードを切り替えるリンクUIにスタイルを付与しました。

- 目的: ダイアグラムモードの切り替え操作ができることをより分かりやすくする
- 変更点:
  - `src/DumpDocs.php` の該当DOMを編集（ulタグに変更し、class名をつけました）
  - styleタグを追加

## 補足

- CSSの命名は[BEM](http://getbem.com/introduction/)を使っていますが、揃えたほうが良いルールがありましたら修正します
- DOM構造やUI、挙動など、気づいた/気にある点を見つけたらコメントいただけるとうれしいです🐾

![image](https://user-images.githubusercontent.com/18522005/190558671-fc942626-b2c8-4ace-a832-dde7e661fc99.png)
