### PR TITLE
fix: モード切替のスタイルにfont-familyの指定を追加

### DIFF
--- a/src/DumpDocs.php
+++ b/src/DumpDocs.php
@@ -98,6 +98,10 @@ EOT;
         --font-size-base: 1rem;
       }
 
+      body {
+        font-family: sans-serif;
+      }
+
       .diagram-mode {
         margin-block-end: 2rem;
         border-bottom: 1px solid var(--color-border-base);


### PR DESCRIPTION
下記に立てていただいたIssueの対応ブランチです。

https://github.com/alps-asd/app-state-diagram/issues/172

- bodyにfont-familyの指定を追加しました
- リンクUIの項目やスタイルは別ブランチで対応する想定です