### PR TITLE
Support port option for watch mode

### DIFF
--- a/asd-sync/gulpfile.js
+++ b/asd-sync/gulpfile.js
@@ -7,11 +7,13 @@ const path = require('path');
 const options = minimist(process.argv.slice(2), {
     string: 'profile',
     default: {
-        profile: __dirname + '/alps/alps.json'
+        profile: __dirname + '/alps/alps.json',
+        port: 3000,
     }
 });
 const profile = options.profile;
 const baseDir = path.dirname(profile);
+const port = options.port;
 
 function serve(cb) {
     browserSync({
@@ -21,6 +23,7 @@ function serve(cb) {
         ghostMode: false,
         open: 'external',
         notify: true,
+        port: port,
     });
     cb();
 }

--- a/bin/asd
+++ b/bin/asd
@@ -29,7 +29,7 @@ usage: asd [options] alps_file
 EOT;
     exit(0);
 }
-$options = getopt('c:w::l::m::', ['config:', 'watch::', 'color::', 'and-tag::', 'or-tag::', 'label::', 'mode::']);
+$options = getopt('c:w::l::m::', ['config:', 'watch::', 'color::', 'and-tag::', 'or-tag::', 'label::', 'mode::', 'port::']);
 if ($argc === 1) {
     $options['c'] = getcwd();
 }

--- a/bin/asd
+++ b/bin/asd
@@ -49,7 +49,8 @@ if ($config->watch) {
     if ($isFirstRun) {
         passthru('npm install');
     }
-    passthru('npm start -- --profile ' . $config->profile);
+
+    passthru("npm start -- --profile {$config->profile} --port {$config->port}");
     exit(0);
 }
 

--- a/docs/asd.sh
+++ b/docs/asd.sh
@@ -10,9 +10,16 @@ argc=$#
 options=${*:1:$((argc-1))}
 target=${*:argc:1}
 
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --port=*) ARG="$1"; PORT+=("${ARG#*=}"); unset ARG; shift;;
+    *) shift;;
+  esac
+done
+
 profile=$(cd "$(dirname "$target")" || exit; pwd)/$(basename "$target") # path/to/profile.xml (absolute path)
 dir=$(dirname "$profile") # path/to
 basename=$(basename "$profile") # profile.xml
 
 docker pull ghcr.io/alps-asd/app-state-diagram:latest
-docker run --env COMPOSER_PROCESS_TIMEOUT=0 -v "$dir:/work" -it --init --rm --name asd -p 3000:3000 ghcr.io/alps-asd/app-state-diagram composer global exec asd -- "$options" /work/"$basename"
+docker run --env COMPOSER_PROCESS_TIMEOUT=0 -v "$dir:/work" -it --init --rm -p ${port}:${port} ghcr.io/alps-asd/app-state-diagram composer global exec asd -- "$options" /work/"$basename"

--- a/docs/asd.xsd
+++ b/docs/asd.xsd
@@ -9,6 +9,7 @@
             <xs:choice maxOccurs="unbounded">
                 <xs:element ref="alpsFile"/>
                 <xs:element ref="watch"/>
+                <xs:element ref="port"/>
                 <xs:element ref="filter"/>
                 <xs:element ref="label"/>
                 <xs:element ref="mode"/>
@@ -25,6 +26,17 @@
         <xs:annotation>
             <xs:documentation>Rendering in watch mode</xs:documentation>
         </xs:annotation>
+    </xs:element>
+    <xs:element name="port" default="3000">
+        <xs:annotation>
+            <xs:documentation>Watch mode server port</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+            <xs:restriction base="xs:integer">
+                <xs:minInclusive value="1024"/>
+                <xs:maxInclusive value="49151"/>
+            </xs:restriction>
+        </xs:simpleType>
     </xs:element>
     <xs:element name="filter" type="filterType" >
         <xs:annotation>

--- a/src/Config.php
+++ b/src/Config.php
@@ -25,8 +25,16 @@ final class Config
     /** @var string */
     public $outputMode;
 
-    public function __construct(string $profile, bool $watch, ConfigFilter $filter, string $outputMode = DumpDocs::MODE_HTML)
-    {
+    /** @var int */
+    public $port;
+
+    public function __construct(
+        string $profile,
+        bool $watch,
+        ConfigFilter $filter,
+        string $outputMode = DumpDocs::MODE_HTML,
+        int $port = 3000
+    ) {
         if (! is_file($profile)) {
             throw new AlpsFileNotReadableException($profile);
         }
@@ -36,5 +44,6 @@ final class Config
         $this->filter = $filter;
         $this->hasTag = $filter->and || $filter->or;
         $this->outputMode = $outputMode;
+        $this->port = $port;
     }
 }

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -32,13 +32,15 @@ final class ConfigFactory
         /** @var ?SimpleXMLElement $filter */
         $filter = property_exists($xml, 'filter') ? $xml->filter : null;
         $mode = property_exists($xml, 'mode') ? (string) $xml->mode : DumpDocs::MODE_HTML;
-        $option = new Option($options, $filter);
+        $port = property_exists($xml, 'port') ? (int) $xml->port : null;
+        $option = new Option($options, $filter, $port);
 
         return new Config(
             $profile,
             $option->watch,
             new ConfigFilter($option->and, $option->or, $option->color),
-            $mode
+            $mode,
+            $option->port,
         );
     }
 
@@ -48,13 +50,14 @@ final class ConfigFactory
      */
     public static function fromCommandLine(int $argc, array $argv, array $options): Config
     {
-        $option = new Option($options, null);
+        $option = new Option($options, null, null);
 
         return new Config(
             (string) realpath($argv[$argc - 1]),
             $option->watch,
             new ConfigFilter($option->and, $option->or, $option->color),
-            $option->mode
+            $option->mode,
+            $option->port,
         );
     }
 }

--- a/src/Option.php
+++ b/src/Option.php
@@ -6,6 +6,7 @@ namespace Koriym\AppStateDiagram;
 
 use SimpleXMLElement;
 
+use function array_values;
 use function explode;
 use function filter_var;
 use function is_string;
@@ -56,15 +57,15 @@ final class Option
             return explode(',', $options['and-tag']);
         }
 
-        /** @var array<string> */ // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat
+        /** @var list<string> */ // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat
 
-        return $filter instanceof SimpleXMLElement && property_exists($filter, 'and') ? (array) $filter->and : [];
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'and') ? array_values((array) $filter->and) : [];
     }
 
     /**
      * @param array<string, string|bool> $options
      *
-     * @return array<string>
+     * @return list<string>
      */
     private function parseOrTag(array $options, ?SimpleXMLElement $filter): array
     {
@@ -72,9 +73,9 @@ final class Option
             return explode(',', $options['or-tag']);
         }
 
-        /** @var array<string> */ // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat
+        /** @var list<string> */ // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat
 
-        return $filter instanceof SimpleXMLElement && property_exists($filter, 'or') ? (array) $filter->or : [];
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'or') ? array_values((array) $filter->or) : [];
     }
 
     /** @param array<string, string|bool> $options */

--- a/tests/ConfigLoadTest.php
+++ b/tests/ConfigLoadTest.php
@@ -20,6 +20,7 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['tag1', 'tag2'], $config->filter->and);
         $this->assertSame(['tag3'], $config->filter->or);
         $this->assertSame(DumpDocs::MODE_MARKDOWN, $config->outputMode);
+        $this->assertSame(3000, $config->port);
     }
 
     /** @return array<string, mixed> */
@@ -40,6 +41,7 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['a', 'b'], $config->filter->and);
         $this->assertSame(['c', 'd'], $config->filter->or);
         $this->assertSame('red', $config->filter->color);
+        $this->assertSame(3000, $config->port);
 
         return $options;
     }
@@ -58,6 +60,7 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['a', 'b'], $config->filter->and);
         $this->assertSame(['c', 'd'], $config->filter->or);
         $this->assertSame('red', $config->filter->color);
+        $this->assertSame(3000, $config->port);
     }
 
     public function testInvalidProfile(): void

--- a/tests/ConfigLoadTest.php
+++ b/tests/ConfigLoadTest.php
@@ -33,6 +33,7 @@ class ConfigLoadTest extends TestCase
             'color' => 'red',
             'label' => 'title',
             '-c' => __DIR__ . '/Fake/config',
+            'port' => '3001',
         ];
         $config = ConfigFactory::fromFile(__DIR__ . '/Fake/config', 1, [__DIR__ . '/Fake/alps.json'], $options);
         $this->assertSame(__DIR__ . '/Fake/alps.json', $config->profile);
@@ -41,7 +42,7 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['a', 'b'], $config->filter->and);
         $this->assertSame(['c', 'd'], $config->filter->or);
         $this->assertSame('red', $config->filter->color);
-        $this->assertSame(3000, $config->port);
+        $this->assertSame(3001, $config->port);
 
         return $options;
     }
@@ -60,7 +61,7 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['a', 'b'], $config->filter->and);
         $this->assertSame(['c', 'd'], $config->filter->or);
         $this->assertSame('red', $config->filter->color);
-        $this->assertSame(3000, $config->port);
+        $this->assertSame(3001, $config->port);
     }
 
     public function testInvalidProfile(): void

--- a/tests/Fake/config/asd.xml
+++ b/tests/Fake/config/asd.xml
@@ -3,6 +3,7 @@
      xsi:noNamespaceSchemaLocation="../../../docs/asd.xsd">
     <alpsFile>profile.xml</alpsFile>
     <watch>false</watch>
+    <port>3000</port>
     <filter>
         <and>tag1</and>
         <and>tag2</and>


### PR DESCRIPTION
Fixed #176 

* watch モードで任意のポートで起動できるように `port` オプションを追加
  * ex: `bin/asd --watch --port=3001 docs/todomvc/profile.json` 
* asd.sh での起動時には、オプションからポート番号を取得し、コンテナのバインドポートに利用
  * ex: `docs/asd.sh --watch --port=3001 docs/todomvc/profile.json`

なお、このブランチの `docs/asd.sh` は指定したportでコンテナは起動しますが、コンテナ内のアプリケーション自体は変更前のものなので、指定されたportでwatchモード自体は起動されません。 