### PR TITLE
refactor: break down IndexPage massive constructor

### DIFF
--- a/docs/assets/js/zoom.js
+++ b/docs/assets/js/zoom.js
@@ -1,0 +1,107 @@
+// グラフズーム機能のセットアップ（+/-ボタンのみ）
+let currentScale = 1;
+const minScale = 0.1;
+const maxScale = 3;
+
+function setupGraphZoom() {
+    console.log("Setting up zoom controls...");
+    const zoomControlsContainer = document.querySelector('#zoom-controls-container');
+    if (!zoomControlsContainer) {
+        console.log('Zoom controls container not found');
+        return;
+    }
+
+    // グローバルなズームコントロールを追加
+    const zoomControls = document.createElement('div');
+    zoomControls.className = 'zoom-controls global-zoom-controls';
+    zoomControls.innerHTML = `
+        <button class="zoom-button" data-zoom="in">+</button>
+        <button class="zoom-button" data-zoom="out">−</button>
+        <button class="zoom-button" data-zoom="reset">1:1</button>
+    `;
+    zoomControlsContainer.appendChild(zoomControls);
+    
+    // SVG要素の監視と初期設定
+    setupSvgObservers();
+    
+    // ズームイン
+    zoomControls.querySelector('[data-zoom="in"]').addEventListener('click', () => {
+        currentScale = Math.min(currentScale * 1.2, maxScale);
+        updateAllSvgZoom(zoomControls);
+    });
+
+    // ズームアウト
+    zoomControls.querySelector('[data-zoom="out"]').addEventListener('click', () => {
+        currentScale = Math.max(currentScale / 1.2, minScale);
+        updateAllSvgZoom(zoomControls);
+    });
+
+    // リセット
+    zoomControls.querySelector('[data-zoom="reset"]').addEventListener('click', () => {
+        currentScale = 1;
+        updateAllSvgZoom(zoomControls);
+    });
+}
+
+function setupSvgObservers() {
+    const containers = ['#asd-graph-id', '#asd-graph-name'];
+    
+    containers.forEach(containerId => {
+        const container = document.querySelector(containerId);
+        if (!container) {
+            console.log(`Container ${containerId} not found`);
+            return;
+        }
+        
+        // SVGを探す
+        let svg = container.querySelector('svg');
+        
+        // SVGが見つからない場合は監視して再試行
+        if (!svg) {
+            console.log(`SVG not found in ${containerId}, setting up observer`);
+            // SVG要素が追加されるのを監視
+            const observer = new MutationObserver((mutations, obs) => {
+                mutations.forEach(mutation => {
+                    if (mutation.addedNodes.length) {
+                        svg = container.querySelector('svg');
+                        if (svg) {
+                            console.log('SVG found in ' + containerId + ' after waiting');
+                            obs.disconnect(); // 監視を停止
+                            // 初期ズームを適用
+                            svg.style.transform = `scale(${currentScale})`;
+                        }
+                    }
+                });
+            });
+            
+            observer.observe(container, { childList: true, subtree: true });
+        } else {
+            console.log(`SVG found immediately ${containerId}`);
+            // 初期ズームを適用
+            svg.style.transform = `scale(${currentScale})`;
+        }
+    });
+}
+
+function updateAllSvgZoom(zoomControls) {
+    // 両方のコンテナのSVGを取得して同じスケールを適用
+    const containers = ['#asd-graph-id', '#asd-graph-name'];
+    
+    containers.forEach(containerId => {
+        const container = document.querySelector(containerId);
+        if (!container) return;
+        
+        const svg = container.querySelector('svg');
+        if (svg) {
+            // transform-originはCSSで設定済み（top left）
+            svg.style.transform = `scale(${currentScale})`;
+        }
+    });
+    
+    // ボタン状態の更新
+    const zoomIn = zoomControls.querySelector('[data-zoom="in"]');
+    const zoomOut = zoomControls.querySelector('[data-zoom="out"]');
+    
+    zoomIn.disabled = currentScale >= maxScale;
+    zoomOut.disabled = currentScale <= minScale;
+}

--- a/src/IndexPage.php
+++ b/src/IndexPage.php
@@ -261,6 +261,11 @@ EOT;
 EOT;
     }
 
+    /**
+     * Generates the main JavaScript for graph rendering and interaction setup.
+     * @param string $setUpTagEvents Tag event setup JavaScript code
+     * @return string JavaScript code wrapped in script tags
+     */
     private function generateMainScript(string $setUpTagEvents): string
     {
         return <<<EOT

--- a/src/IndexPage.php
+++ b/src/IndexPage.php
@@ -38,14 +38,15 @@ final class IndexPage
         $header = $this->generateHtmlHeader();
         $legend = $config->outputMode === DumpDocs::MODE_MARKDOWN ? '' : IndexPageElements::LEGEND;
         $tags = $config->outputMode === DumpDocs::MODE_MARKDOWN ? '' : $index->tags;
-        $asd = $config->outputMode === DumpDocs::MODE_MARKDOWN ? 
-            $this->getMarkdownImage($config->profile) : 
+        $asd = $config->outputMode === DumpDocs::MODE_MARKDOWN ?
+            $this->getMarkdownImage($config->profile) :
             $this->generateSvgContainer($index->setUpTagEvents);
 
         $this->file = sprintf('%s/index.%s', dirname($index->profile->alpsFile), $index->ext);
-        
+
         if ($index->mode === DumpDocs::MODE_MARKDOWN) {
             $this->content = $this->generateMarkdownContent($index, $asd, $tags, $legend);
+
             return;
         }
 
@@ -369,17 +370,17 @@ EOT;
         $md = $this->generateMarkdownContent($index, $asd, $tags, $legend);
         $legendTypeMd = $this->getLegendTypeMd($md);
         assert($legendTypeMd !== '', 'Regexp failed');
-        
+
         $html = (new MdToHtml())($index->htmlTitle, $legendTypeMd);
         $escapedDotId = str_replace("\n", '', $index->dotId);
         $escapedDotName = str_replace("\n", '', $index->dotName);
-        
+
         $plusHeaderHtml = str_replace(
             '</head>',
             $header . '</head>',
             $html
         );
-        
+
         return str_replace(['{{ dotId }}', '{{ dotName }}', '{{ dotName }}'], [$escapedDotId, $escapedDotName], $plusHeaderHtml);
     }
 }

--- a/src/IndexPage.php
+++ b/src/IndexPage.php
@@ -32,25 +32,168 @@ final class IndexPage
     /** @var string */
     public $file;
 
-    /** @SuppressWarnings(PHPMD.ExcessiveMethodLength)  */
     public function __construct(Config $config)
     {
         $index = $this->getElements($config);
+        $header = $this->generateHtmlHeader();
+        $legend = $config->outputMode === DumpDocs::MODE_MARKDOWN ? '' : IndexPageElements::LEGEND;
+        $tags = $config->outputMode === DumpDocs::MODE_MARKDOWN ? '' : $index->tags;
+        $asd = $config->outputMode === DumpDocs::MODE_MARKDOWN ? 
+            $this->getMarkdownImage($config->profile) : 
+            $this->generateSvgContainer($index->setUpTagEvents);
+
+        $this->file = sprintf('%s/index.%s', dirname($index->profile->alpsFile), $index->ext);
+        
+        if ($index->mode === DumpDocs::MODE_MARKDOWN) {
+            $this->content = $this->generateMarkdownContent($index, $asd, $tags, $legend);
+            return;
+        }
+
+        $this->content = $this->generateHtmlContent($index, $asd, $tags, $legend, $header);
+    }
+
+    private function getLegendTypeMd(string $md): string
+    {
+        $pattern = '/^(\|\s*)(semantic|safe|unsafe|idempotent)(\s*\|)/m';
+        $replacement = '$1<span class="legend"><span class="legend-icon $2"></span></span>$3';
+
+        return (string) preg_replace($pattern, $replacement, $md);
+    }
+
+    private function getMarkdownImage(string $profile): string
+    {
+        $baseProfile = basename($profile);
+        $imageFile = str_replace(['.xml', '.json'], '.svg', $baseProfile);
+        $imageTitleFile = str_replace(['.xml', '.json'], '.title.svg', $baseProfile);
+
+        return sprintf(
+            '[<img src="%s" alt="application state diagram">](%s)',
+            $imageFile,
+            $imageTitleFile
+        );
+    }
+
+    /** @param array<string, list<string>> $tags */
+    private function tags(array $tags): string
+    {
+        if ($tags === []) {
+            return '';
+        }
+
+        $lines = ['<span class="selector-label">Tags:</span>'];
+        $tagKeys = array_keys($tags);
+        foreach ($tagKeys as $tag) {
+            $lines[] = sprintf('<span class="selector-option"><input type="checkbox" id="tag-%s" class="tag-trigger-checkbox" data-tag="%s" name="tag-%s"><label for="tag-%s"> %s</label></span>', $tag, $tag, $tag, $tag, $tag);
+        }
+
+        return sprintf('<div class="selector-container">%s</div>', implode(PHP_EOL, $lines));
+    }
+
+    private function linkRelations(LinkRelations $linkRelations): string
+    {
+        if ((string) $linkRelations === '') {
+            return '';
+        }
+
+        return '## Links' . PHP_EOL . (string) $linkRelations;
+    }
+
+    private function getSetupTagEvents(Config $config): string
+    {
+        $setUpTagEvents = '';
+        $tags = (new Profile($config->profile, new LabelName(), true))->tags;
+        $colors = [
+            'LightGreen',
+            'SkyBlue',
+            'LightCoral',
+            'LightSalmon',
+            'Khaki',
+            'Plum',
+            'Wheat',
+        ];
+        $numberOfColors = count($colors);
+        $i = 0;
+        foreach ($tags as $tag => $ids) {
+            $idArr = [];
+            foreach ($ids as $id) {
+                $idArr[] .= "'{$id}'";
+            }
+
+            $setUpTagEvents .= sprintf("setupTagEventListener('%s', [%s], '%s'); ", $tag, implode(', ', $idArr), $colors[$i++ % $numberOfColors]);
+        }
+
+        return $setUpTagEvents;
+    }
+
+    private function getElements(Config $config): IndexPageElements
+    {
+        $draw = new DrawDiagram();
+        $profile = new Profile($config->profile, new LabelName(), true);
+        $titleProfile = new Profile($config->profile, new LabelNameTitle(), true);
+        $dotId = $draw($profile, new LabelName());
+        $dotName = $draw($titleProfile, new LabelNameTitle());
+        $mode = $config->outputMode;
+        $alpsProfile = htmlspecialchars(
+            (string) file_get_contents($profile->alpsFile),
+            ENT_QUOTES,
+            'UTF-8'
+        );
+
+        $semanticMd = PHP_EOL . (new DumpDocs())->getSemanticDescriptorMarkDown($profile);
+        $descriptors = $profile->descriptors;
+        uasort($descriptors, static function (AbstractDescriptor $a, AbstractDescriptor $b): int {
+            $compareId = strtoupper($a->id) <=> strtoupper($b->id);
+            if ($compareId !== 0) {
+                return $compareId;
+            }
+
+            $order = ['semantic' => 0, 'safe' => 1, 'unsafe' => 2, 'idempotent' => 3];
+
+            return $order[$a->type] <=> $order[$b->type];
+        });
+        $linkRelations = $this->linkRelations($profile->linkRelations);
+        $ext = $mode === DumpDocs::MODE_MARKDOWN ? 'md' : DumpDocs::MODE_HTML;
+        $tags = $this->tags($profile->tags);
+        $htmlTitle = htmlspecialchars($profile->title ?: 'ALPS');
+        $htmlDoc = nl2br(htmlspecialchars($profile->doc));
+        $setUpTagEvents = $this->getSetupTagEvents($config);
+
+        return new IndexPageElements(
+            $profile,
+            $dotId,
+            $dotName,
+            $mode,
+            $alpsProfile,
+            $semanticMd,
+            $linkRelations,
+            $ext,
+            $tags,
+            $htmlTitle,
+            $htmlDoc,
+            $setUpTagEvents
+        );
+    }
+
+    private function generateHtmlHeader(): string
+    {
         $indexJsFile = dirname(__DIR__, 1) . '/docs/assets/js/main.js';
         $isDevelop = file_exists($indexJsFile) && file_exists(dirname(__DIR__) . '/.develop');
         $indexJs = $isDevelop ?
             sprintf('<script>%s</script>', (string) file_get_contents($indexJsFile)) :
             '<script src="https://www.app-state-diagram.com/app-state-diagram/assets/js/main.js"></script>'; // @codeCoverageIgnore
-        $header = <<<EOT
+
+        return <<<EOT
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://unpkg.com/@hpcc-js/wasm@2.21.0/dist/graphviz.umd.js" type="javascript/worker"></script>
     <script src="https://unpkg.com/d3-graphviz@5.6.0/build/d3-graphviz.min.js"></script>
 {$indexJs}
 
 EOT;
-        $legend = $config->outputMode === DumpDocs::MODE_MARKDOWN ? '' : IndexPageElements::LEGEND;
-        $tags = $config->outputMode === DumpDocs::MODE_MARKDOWN ? '' : $index->tags;
-        $asd = $config->outputMode === DumpDocs::MODE_MARKDOWN ? $this->getMarkdownImage($config->profile) : <<< EOTJS
+    }
+
+    private function generateSvgContainer(string $setUpTagEvents): string
+    {
+        return <<< EOTJS
 <div id="svg-container">
     <div id="asd-graph-id" style="text-align: center; "></div>
     <div id="asd-graph-name" style="text-align: center; display: none;"></div>
@@ -68,7 +211,7 @@ EOT;
             applySmoothScrollToLinks(document.querySelectorAll('a[href^="#"]'));
             setupTagClick();
             setupDocClick();
-            {$index->setUpTagEvents}
+            {$setUpTagEvents}
 
             // 新機能の初期化
             enhanceProfileSection();
@@ -195,8 +338,11 @@ EOT;
     <label for="asd-show-name">title</label>
 </div>
 EOTJS;
+    }
 
-        $md = <<<EOT
+    private function generateMarkdownContent(IndexPageElements $index, string $asd, string $tags, string $legend): string
+    {
+        return <<<EOT
 # {$index->htmlTitle}
 
 {$index->htmlDoc}
@@ -216,146 +362,24 @@ EOTJS;
 ## Profile
 <pre><code>{$index->alpsProfile}</code></pre>
 EOT;
-        $this->file = sprintf('%s/index.%s', dirname($index->profile->alpsFile), $index->ext);
-        if ($index->mode === DumpDocs::MODE_MARKDOWN) {
-            $this->content = $md;
+    }
 
-            return;
-        }
-
-        // HTML format
+    private function generateHtmlContent(IndexPageElements $index, string $asd, string $tags, string $legend, string $header): string
+    {
+        $md = $this->generateMarkdownContent($index, $asd, $tags, $legend);
         $legendTypeMd = $this->getLegendTypeMd($md);
         assert($legendTypeMd !== '', 'Regexp failed');
+        
         $html = (new MdToHtml())($index->htmlTitle, $legendTypeMd);
         $escapedDotId = str_replace("\n", '', $index->dotId);
         $escapedDotName = str_replace("\n", '', $index->dotName);
+        
         $plusHeaderHtml = str_replace(
             '</head>',
             $header . '</head>',
             $html
         );
-        $this->content = str_replace(['{{ dotId }}', '{{ dotName }}', '{{ dotName }}'], [$escapedDotId, $escapedDotName], $plusHeaderHtml);
-    }
-
-    private function getLegendTypeMd(string $md): string
-    {
-        $pattern = '/^(\|\s*)(semantic|safe|unsafe|idempotent)(\s*\|)/m';
-        $replacement = '$1<span class="legend"><span class="legend-icon $2"></span></span>$3';
-
-        return (string) preg_replace($pattern, $replacement, $md);
-    }
-
-    private function getMarkdownImage(string $profile): string
-    {
-        $baseProfile = basename($profile);
-        $imageFile = str_replace(['.xml', '.json'], '.svg', $baseProfile);
-        $imageTitleFile = str_replace(['.xml', '.json'], '.title.svg', $baseProfile);
-
-        return sprintf(
-            '[<img src="%s" alt="application state diagram">](%s)',
-            $imageFile,
-            $imageTitleFile
-        );
-    }
-
-    /** @param array<string, list<string>> $tags */
-    private function tags(array $tags): string
-    {
-        if ($tags === []) {
-            return '';
-        }
-
-        $lines = ['<span class="selector-label">Tags:</span>'];
-        $tagKeys = array_keys($tags);
-        foreach ($tagKeys as $tag) {
-            $lines[] = sprintf('<span class="selector-option"><input type="checkbox" id="tag-%s" class="tag-trigger-checkbox" data-tag="%s" name="tag-%s"><label for="tag-%s"> %s</label></span>', $tag, $tag, $tag, $tag, $tag);
-        }
-
-        return sprintf('<div class="selector-container">%s</div>', implode(PHP_EOL, $lines));
-    }
-
-    private function linkRelations(LinkRelations $linkRelations): string
-    {
-        if ((string) $linkRelations === '') {
-            return '';
-        }
-
-        return '## Links' . PHP_EOL . (string) $linkRelations;
-    }
-
-    private function getSetupTagEvents(Config $config): string
-    {
-        $setUpTagEvents = '';
-        $tags = (new Profile($config->profile, new LabelName(), true))->tags;
-        $colors = [
-            'LightGreen',
-            'SkyBlue',
-            'LightCoral',
-            'LightSalmon',
-            'Khaki',
-            'Plum',
-            'Wheat',
-        ];
-        $numberOfColors = count($colors);
-        $i = 0;
-        foreach ($tags as $tag => $ids) {
-            $idArr = [];
-            foreach ($ids as $id) {
-                $idArr[] .= "'{$id}'";
-            }
-
-            $setUpTagEvents .= sprintf("setupTagEventListener('%s', [%s], '%s'); ", $tag, implode(', ', $idArr), $colors[$i++ % $numberOfColors]);
-        }
-
-        return $setUpTagEvents;
-    }
-
-    private function getElements(Config $config): IndexPageElements
-    {
-        $draw = new DrawDiagram();
-        $profile = new Profile($config->profile, new LabelName(), true);
-        $titleProfile = new Profile($config->profile, new LabelNameTitle(), true);
-        $dotId = $draw($profile, new LabelName());
-        $dotName = $draw($titleProfile, new LabelNameTitle());
-        $mode = $config->outputMode;
-        $alpsProfile = htmlspecialchars(
-            (string) file_get_contents($profile->alpsFile),
-            ENT_QUOTES,
-            'UTF-8'
-        );
-
-        $semanticMd = PHP_EOL . (new DumpDocs())->getSemanticDescriptorMarkDown($profile);
-        $descriptors = $profile->descriptors;
-        uasort($descriptors, static function (AbstractDescriptor $a, AbstractDescriptor $b): int {
-            $compareId = strtoupper($a->id) <=> strtoupper($b->id);
-            if ($compareId !== 0) {
-                return $compareId;
-            }
-
-            $order = ['semantic' => 0, 'safe' => 1, 'unsafe' => 2, 'idempotent' => 3];
-
-            return $order[$a->type] <=> $order[$b->type];
-        });
-        $linkRelations = $this->linkRelations($profile->linkRelations);
-        $ext = $mode === DumpDocs::MODE_MARKDOWN ? 'md' : DumpDocs::MODE_HTML;
-        $tags = $this->tags($profile->tags);
-        $htmlTitle = htmlspecialchars($profile->title ?: 'ALPS');
-        $htmlDoc = nl2br(htmlspecialchars($profile->doc));
-        $setUpTagEvents = $this->getSetupTagEvents($config);
-
-        return new IndexPageElements(
-            $profile,
-            $dotId,
-            $dotName,
-            $mode,
-            $alpsProfile,
-            $semanticMd,
-            $linkRelations,
-            $ext,
-            $tags,
-            $htmlTitle,
-            $htmlDoc,
-            $setUpTagEvents
-        );
+        
+        return str_replace(['{{ dotId }}', '{{ dotName }}', '{{ dotName }}'], [$escapedDotId, $escapedDotName], $plusHeaderHtml);
     }
 }

--- a/src/IndexPage.php
+++ b/src/IndexPage.php
@@ -263,7 +263,9 @@ EOT;
 
     /**
      * Generates the main JavaScript for graph rendering and interaction setup.
+     *
      * @param string $setUpTagEvents Tag event setup JavaScript code
+     *
      * @return string JavaScript code wrapped in script tags
      */
     private function generateMainScript(string $setUpTagEvents): string

--- a/src/IndexPage.php
+++ b/src/IndexPage.php
@@ -284,7 +284,7 @@ EOT;
             setupDocClick();
             {$setUpTagEvents}
 
-            // 新機能の初期化
+            // Initialize new features
             enhanceProfileSection();
             setupSearch();
             setupGraphZoom();

--- a/src/IndexPage.php
+++ b/src/IndexPage.php
@@ -178,167 +178,34 @@ final class IndexPage
     private function generateHtmlHeader(): string
     {
         $indexJsFile = dirname(__DIR__, 1) . '/docs/assets/js/main.js';
+        $zoomJsFile = dirname(__DIR__, 1) . '/docs/assets/js/zoom.js';
         $isDevelop = file_exists($indexJsFile) && file_exists(dirname(__DIR__) . '/.develop');
+
         $indexJs = $isDevelop ?
             sprintf('<script>%s</script>', (string) file_get_contents($indexJsFile)) :
             '<script src="https://www.app-state-diagram.com/app-state-diagram/assets/js/main.js"></script>'; // @codeCoverageIgnore
+
+        $zoomJs = $isDevelop ?
+            sprintf('<script>%s</script>', (string) file_get_contents($zoomJsFile)) :
+            '<script src="https://www.app-state-diagram.com/app-state-diagram/assets/js/zoom.js"></script>'; // @codeCoverageIgnore
 
         return <<<EOT
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://unpkg.com/@hpcc-js/wasm@2.21.0/dist/graphviz.umd.js" type="javascript/worker"></script>
     <script src="https://unpkg.com/d3-graphviz@5.6.0/build/d3-graphviz.min.js"></script>
 {$indexJs}
+{$zoomJs}
 
 EOT;
     }
 
     private function generateSvgContainer(string $setUpTagEvents): string
     {
-        return <<< EOTJS
-<div id="svg-container">
-    <div id="asd-graph-id" style="text-align: center; "></div>
-    <div id="asd-graph-name" style="text-align: center; display: none;"></div>
-</div>
-<script>
-    document.addEventListener('DOMContentLoaded', async function() {
-        try {
-            await Promise.all([
-                    renderGraph("#asd-graph-id", '{{ dotId }}'),
-                    renderGraph("#asd-graph-name", '{{ dotName }}')
-            ]);
-            setupTagTrigger();
-            setupModeSwitch('asd-show-id', 'asd-graph-id', 'asd-graph-name');
-            setupModeSwitch('asd-show-name', 'asd-graph-name', 'asd-graph-id');
-            applySmoothScrollToLinks(document.querySelectorAll('a[href^="#"]'));
-            setupTagClick();
-            setupDocClick();
-            {$setUpTagEvents}
+        $htmlContainer = $this->generateSvgHtmlContainer();
+        $mainScript = $this->generateMainScript($setUpTagEvents);
+        $controls = $this->generateViewControls();
 
-            // 新機能の初期化
-            enhanceProfileSection();
-            setupSearch();
-            setupGraphZoom();
-        } catch (error) {
-               console.error("Error in main process:", error);
-        }});
-        
-    // グラフズーム機能のセットアップ（+/-ボタンのみ）
-    let currentScale = 1;
-    const minScale = 0.1;
-    const maxScale = 3;
-
-    function setupGraphZoom() {
-        console.log("Setting up zoom controls...");
-        const zoomControlsContainer = document.querySelector('#zoom-controls-container');
-        if (!zoomControlsContainer) {
-            console.log('Zoom controls container not found');
-            return;
-        }
-
-        // グローバルなズームコントロールを追加
-        const zoomControls = document.createElement('div');
-        zoomControls.className = 'zoom-controls global-zoom-controls';
-        zoomControls.innerHTML = `
-            <button class="zoom-button" data-zoom="in">+</button>
-            <button class="zoom-button" data-zoom="out">−</button>
-            <button class="zoom-button" data-zoom="reset">1:1</button>
-        `;
-        zoomControlsContainer.appendChild(zoomControls);
-        
-        // SVG要素の監視と初期設定
-        setupSvgObservers();
-        
-        // ズームイン
-        zoomControls.querySelector('[data-zoom="in"]').addEventListener('click', () => {
-            currentScale = Math.min(currentScale * 1.2, maxScale);
-            updateAllSvgZoom(zoomControls);
-        });
-    
-        // ズームアウト
-        zoomControls.querySelector('[data-zoom="out"]').addEventListener('click', () => {
-            currentScale = Math.max(currentScale / 1.2, minScale);
-            updateAllSvgZoom(zoomControls);
-        });
-    
-        // リセット
-        zoomControls.querySelector('[data-zoom="reset"]').addEventListener('click', () => {
-            currentScale = 1;
-            updateAllSvgZoom(zoomControls);
-        });
-    }
-    
-    function setupSvgObservers() {
-        const containers = ['#asd-graph-id', '#asd-graph-name'];
-        
-        containers.forEach(containerId => {
-            const container = document.querySelector(containerId);
-            if (!container) {
-                console.log(`Container \${containerId} not found`);
-                return;
-            }
-            
-            // SVGを探す
-            let svg = container.querySelector('svg');
-            
-            // SVGが見つからない場合は監視して再試行
-            if (!svg) {
-                console.log(`SVG not found in \${containerId}, setting up observer`);
-                // SVG要素が追加されるのを監視
-                const observer = new MutationObserver((mutations, obs) => {
-                    mutations.forEach(mutation => {
-                        if (mutation.addedNodes.length) {
-                            svg = container.querySelector('svg');
-                            if (svg) {
-                                console.log('SVG found in ' + containerId + ' after waiting');
-                                obs.disconnect(); // 監視を停止
-                                // 初期ズームを適用
-                                svg.style.transform = `scale(\${currentScale})`;
-                            }
-                        }
-                    });
-                });
-                
-                observer.observe(container, { childList: true, subtree: true });
-            } else {
-                console.log(`SVG found immediately \${containerId}`);
-                // 初期ズームを適用
-                svg.style.transform = `scale(\${currentScale})`;
-            }
-        });
-    }
-    
-    function updateAllSvgZoom(zoomControls) {
-        // 両方のコンテナのSVGを取得して同じスケールを適用
-        const containers = ['#asd-graph-id', '#asd-graph-name'];
-        
-        containers.forEach(containerId => {
-            const container = document.querySelector(containerId);
-            if (!container) return;
-            
-            const svg = container.querySelector('svg');
-            if (svg) {
-                // transform-originはCSSで設定済み（top left）
-                svg.style.transform = `scale(\${currentScale})`;
-            }
-        });
-        
-        // ボタン状態の更新
-        const zoomIn = zoomControls.querySelector('[data-zoom="in"]');
-        const zoomOut = zoomControls.querySelector('[data-zoom="out"]');
-        
-        zoomIn.disabled = currentScale >= maxScale;
-        zoomOut.disabled = currentScale <= minScale;
-    }
-</script>
-<div id="zoom-controls-container" style="margin-bottom: 10px;"></div>
-<div class="asd-view-selector">
-    <span class="selector-label">View:</span>
-    <input type="radio" id="asd-show-id" checked name="asd-view-selector">
-    <label for="asd-show-id">id</label>
-    <input type="radio" id="asd-show-name" name="asd-view-selector">
-    <label for="asd-show-name">title</label>
-</div>
-EOTJS;
+        return $htmlContainer . $mainScript . $controls;
     }
 
     private function generateMarkdownContent(IndexPageElements $index, string $asd, string $tags, string $legend): string
@@ -382,5 +249,58 @@ EOT;
         );
 
         return str_replace(['{{ dotId }}', '{{ dotName }}', '{{ dotName }}'], [$escapedDotId, $escapedDotName], $plusHeaderHtml);
+    }
+
+    private function generateSvgHtmlContainer(): string
+    {
+        return <<<'EOT'
+<div id="svg-container">
+	<div id="asd-graph-id" style="text-align: center; "></div>
+	<div id="asd-graph-name" style="text-align: center; display: none;"></div>
+</div>
+EOT;
+    }
+
+    private function generateMainScript(string $setUpTagEvents): string
+    {
+        return <<<EOT
+<script>
+    document.addEventListener('DOMContentLoaded', async function() {
+        try {
+            await Promise.all([
+                    renderGraph("#asd-graph-id", '{{ dotId }}'),
+                    renderGraph("#asd-graph-name", '{{ dotName }}')
+            ]);
+            setupTagTrigger();
+            setupModeSwitch('asd-show-id', 'asd-graph-id', 'asd-graph-name');
+            setupModeSwitch('asd-show-name', 'asd-graph-name', 'asd-graph-id');
+            applySmoothScrollToLinks(document.querySelectorAll('a[href^="#"]'));
+            setupTagClick();
+            setupDocClick();
+            {$setUpTagEvents}
+
+            // 新機能の初期化
+            enhanceProfileSection();
+            setupSearch();
+            setupGraphZoom();
+        } catch (error) {
+               console.error("Error in main process:", error);
+        }});
+</script>
+EOT;
+    }
+
+    private function generateViewControls(): string
+    {
+        return <<<'EOT'
+<div id="zoom-controls-container" style="margin-bottom: 10px;"></div>
+<div class="asd-view-selector">
+	<span class="selector-label">View:</span>
+	<input type="radio" id="asd-show-id" checked name="asd-view-selector">
+	<label for="asd-show-id">id</label>
+	<input type="radio" id="asd-show-name" name="asd-view-selector">
+	<label for="asd-show-name">title</label>
+</div>
+EOT;
     }
 }

--- a/src/IndexPageElements.php
+++ b/src/IndexPageElements.php
@@ -29,7 +29,7 @@ final class IndexPageElements
 </div>
 ';
 
-    /** @SuppressWarnings(PHPMD.ExcessiveParameterList) */
+    /** @SuppressWarnings("PHPMD.ExcessiveParameterList") */
     public function __construct(
         public readonly Profile $profile,
         public readonly string $dotId,

--- a/src/NullDescriptor.php
+++ b/src/NullDescriptor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\AppStateDiagram;
 
-/** @SuppressWarnings(PHPMD.UnusedLocalVariable) */
+/** @SuppressWarnings("PHPMD.UnusedLocalVariable") */
 final class NullDescriptor extends AbstractDescriptor
 {
     public function __construct()

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -36,7 +36,7 @@ final class Profile extends AbstractProfile
     /**
      * @throws ParsingException
      *
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     * @SuppressWarnings("PHPMD.BooleanArgumentFlag")
      */
     public function __construct(
         public string $alpsFile,

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -1138,28 +1138,28 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -1179,9 +1179,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -1189,7 +1189,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -1210,9 +1209,28 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1757,16 +1775,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
                 "shasum": ""
             },
             "require": {
@@ -1809,26 +1827,26 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-05-31T08:24:38+00:00"
         },
         {
             "name": "openmetrics-php/exposition-text",
-            "version": "v0.4.1",
+            "version": "v0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openmetrics-php/exposition-text.git",
-                "reference": "fcfca38f693e168f4520bbd359d91528bbb9a8e8"
+                "reference": "4f65004f93e53eac4b9668879b92d3c200a851ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openmetrics-php/exposition-text/zipball/fcfca38f693e168f4520bbd359d91528bbb9a8e8",
-                "reference": "fcfca38f693e168f4520bbd359d91528bbb9a8e8",
+                "url": "https://api.github.com/repos/openmetrics-php/exposition-text/zipball/4f65004f93e53eac4b9668879b92d3c200a851ba",
+                "reference": "4f65004f93e53eac4b9668879b92d3c200a851ba",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.2 || ^8.0 || ^8.4"
             },
             "require-dev": {
                 "ext-xdebug": "*"
@@ -1852,9 +1870,9 @@
             "description": "Implementation of the text exposition format of OpenMetrics",
             "support": {
                 "issues": "https://github.com/openmetrics-php/exposition-text/issues",
-                "source": "https://github.com/openmetrics-php/exposition-text/tree/v0.4.1"
+                "source": "https://github.com/openmetrics-php/exposition-text/tree/v0.4.2"
             },
-            "time": "2024-07-16T12:47:30+00:00"
+            "time": "2025-06-04T14:59:47+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -2256,16 +2274,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
                 "shasum": ""
             },
             "require": {
@@ -2297,22 +2315,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.2.0"
             },
-            "time": "2025-02-19T13:28:12+00:00"
+            "time": "2025-07-13T07:04:09+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.14",
+            "version": "2.1.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8f2e03099cac24ff3b379864d171c5acbfc6b9a2"
+                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8f2e03099cac24ff3b379864d171c5acbfc6b9a2",
-                "reference": "8f2e03099cac24ff3b379864d171c5acbfc6b9a2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee1f390b7a70cdf74a2b737e554f68afea885db7",
+                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7",
                 "shasum": ""
             },
             "require": {
@@ -2357,7 +2375,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-02T15:32:28+00:00"
+            "time": "2025-07-17T17:22:31+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2769,32 +2787,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.18.0",
+            "version": "8.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "f3b23cb9b26301b8c3c7bb03035a1bee23974593"
+                "reference": "458d665acd49009efebd7e0cb385d71ae9ac3220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/f3b23cb9b26301b8c3c7bb03035a1bee23974593",
-                "reference": "f3b23cb9b26301b8c3c7bb03035a1bee23974593",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/458d665acd49009efebd7e0cb385d71ae9ac3220",
+                "reference": "458d665acd49009efebd7e0cb385d71ae9ac3220",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": "^7.4 || ^8.0",
                 "phpstan/phpdoc-parser": "^2.1.0",
-                "squizlabs/php_codesniffer": "^3.12.2"
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
                 "phing/phing": "3.0.1",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.13",
-                "phpstan/phpstan-deprecation-rules": "2.0.2",
+                "phpstan/phpstan": "2.1.17",
+                "phpstan/phpstan-deprecation-rules": "2.0.3",
                 "phpstan/phpstan-phpunit": "2.0.6",
                 "phpstan/phpstan-strict-rules": "2.0.4",
-                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.17|12.1.3"
+                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.21|12.1.3"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -2818,7 +2836,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.18.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.19.1"
             },
             "funding": [
                 {
@@ -2830,7 +2848,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-01T09:40:50+00:00"
+            "time": "2025-06-09T17:53:57+00:00"
         },
         {
             "name": "spatie/array-to-xml",
@@ -2902,16 +2920,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.2",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa"
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
-                "reference": "6d4cf6032d4b718f168c90a96e36c7d0eaacb2aa",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -2982,20 +3000,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-04-13T04:10:18+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "e0b050b83ba999aa77a3736cb6d5b206d65b9d0d"
+                "reference": "ba62ae565f1327c2f6366726312ed828c85853bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/e0b050b83ba999aa77a3736cb6d5b206d65b9d0d",
-                "reference": "e0b050b83ba999aa77a3736cb6d5b206d65b9d0d",
+                "url": "https://api.github.com/repos/symfony/config/zipball/ba62ae565f1327c2f6366726312ed828c85853bc",
+                "reference": "ba62ae565f1327c2f6366726312ed828c85853bc",
                 "shasum": ""
             },
             "require": {
@@ -3041,7 +3059,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.2.6"
+                "source": "https://github.com/symfony/config/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3057,27 +3075,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-03T21:14:15+00:00"
+            "time": "2025-05-15T09:04:05+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.2.6",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218"
+                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
-                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9e27aecde8f506ba0fd1d9989620c04a87697101",
+                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^6.4|^7.0"
+                "symfony/string": "^7.2"
             },
             "conflict": {
                 "symfony/dependency-injection": "<6.4",
@@ -3134,7 +3153,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.2.6"
+                "source": "https://github.com/symfony/console/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -3150,20 +3169,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-07T19:09:28+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.2.6",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "2ca85496cde37f825bd14f7e3548e2793ca90712"
+                "reference": "8656c4848b48784c4bb8c4ae50d2b43f832cead8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2ca85496cde37f825bd14f7e3548e2793ca90712",
-                "reference": "2ca85496cde37f825bd14f7e3548e2793ca90712",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8656c4848b48784c4bb8c4ae50d2b43f832cead8",
+                "reference": "8656c4848b48784c4bb8c4ae50d2b43f832cead8",
                 "shasum": ""
             },
             "require": {
@@ -3214,7 +3233,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.6"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -3230,20 +3249,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-27T13:37:55+00:00"
+            "time": "2025-06-24T04:04:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -3256,7 +3275,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -3281,7 +3300,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3297,11 +3316,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -3347,7 +3366,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3762,16 +3781,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
                 "shasum": ""
             },
             "require": {
@@ -3789,7 +3808,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -3825,7 +3844,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3841,20 +3860,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2025-04-25T09:37:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931"
+                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
-                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f3570b8c61ca887a9e2938e85cb6458515d2b125",
+                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125",
                 "shasum": ""
             },
             "require": {
@@ -3912,7 +3931,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.2.6"
+                "source": "https://github.com/symfony/string/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -3928,24 +3947,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-20T20:18:16+00:00"
+            "time": "2025-04-20T20:19:01+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "422b8de94c738830a1e071f59ad14d67417d7007"
+                "reference": "c9a1168891b5aaadfd6332ef44393330b3498c4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/422b8de94c738830a1e071f59ad14d67417d7007",
-                "reference": "422b8de94c738830a1e071f59ad14d67417d7007",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/c9a1168891b5aaadfd6332ef44393330b3498c4c",
+                "reference": "c9a1168891b5aaadfd6332ef44393330b3498c4c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
                 "symfony/property-access": "^6.4|^7.0",
@@ -3988,7 +4008,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.2.6"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -4004,20 +4024,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T08:36:00+00:00"
+            "time": "2025-05-15T09:04:05+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.10.2",
+            "version": "6.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "a6c7e2358bbd62d81fca6c149f5c5823ecfcdd2a"
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/a6c7e2358bbd62d81fca6c149f5c5823ecfcdd2a",
-                "reference": "a6c7e2358bbd62d81fca6c149f5c5823ecfcdd2a",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/70cdf647255a1362b426bb0f522a85817b8c791c",
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c",
                 "shasum": ""
             },
             "require": {
@@ -4122,7 +4142,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-05-03T16:37:00+00:00"
+            "time": "2025-07-14T09:59:17+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
## Summary
- Extracted massive IndexPage constructor (240+ lines) into smaller, focused methods
- Improved code maintainability and readability
- Fixed PHPDoc syntax issues for better static analysis compatibility

## Changes
- **generateHtmlHeader()**: Extract JavaScript/CSS dependency management
- **generateSvgContainer()**: Extract SVG container and zoom functionality JavaScript
- **generateMarkdownContent()**: Extract Markdown template generation
- **generateHtmlContent()**: Extract HTML content assembly logic
- Constructor reduced from ~240 lines to 18 lines
- Fixed @SuppressWarnings PHPDoc syntax for PHPStan compatibility

## Benefits
- ✅ Follows Single Responsibility Principle
- ✅ Improved readability and maintainability
- ✅ Better testability (each method can be tested individually)
- ✅ Removed need for @SuppressWarnings(PHPMD.ExcessiveMethodLength)
- ✅ All tests pass
- ✅ Static analysis clean (Psalm & PHPStan)

## Test plan
- [x] All existing tests pass
- [x] Static analysis (Psalm & PHPStan) passes with no errors
- [x] Manual verification of generated HTML/Markdown output

🤖 Generated with [Claude Code](https://claude.ai/code)

## Sourceryによる要約

IndexPage のコンストラクタを、その責務をHTMLヘッダー、SVGコンテナ、マークダウン/HTMLコンテンツ生成、タグ処理、要素組み立てのための専用プライベートメソッドに抽出することによりリファクタリングし、静的解析互換性のためにPHPDocの `@SuppressWarnings` 構文を修正しました。

バグ修正:
- PHPMD互換性のために、引用符付きのルール識別子を含むようにPHPDocの `@SuppressWarnings` アノテーションを修正しました。

改善点:
- IndexPage コンストラクタのロジックを、特化したプライベートメソッド (generateHtmlHeader, generateSvgContainer, generateMarkdownContent, generateHtmlContent, および関連するヘルパーメソッド) に抽出しました。
- コンストラクタを約240行から簡潔な18行のディスパッチャーに削減しました。
- 単一責任の原則を適用することにより、コードの保守性、可読性、テスト容易性を向上させました。

<details>
<summary>Original summary in English</summary>

## Sourceryによる概要

IndexPageコンストラクタを複数の特化したプライベートメソッドにリファクタリングし、グラフのズームロジックを別のzoom.jsアセットに抽出し、互換性のためにPHPDocの@SuppressWarnings構文を修正しました。

新機能:
- グラフのズームコントロールを個別に処理するために、docs/assets/js/zoom.js を追加しました。

バグ修正:
- PHPStanおよびPHPMDとの互換性のために、@SuppressWarnings アノテーションが引用符付きのルール識別子を使用するように修正しました。

改善点:
- 可読性と保守性を向上させるため、IndexPageコンストラクタをプライベートメソッド (generateHtmlHeader, generateSvgContainer, generateMarkdownContent, generateHtmlContent, generateSvgHtmlContainer, generateMainScript, generateViewControls) に分解しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor IndexPage constructor into multiple focused private methods, extract graph zoom logic into a separate zoom.js asset, and correct PHPDoc @SuppressWarnings syntax for compatibility.

New Features:
- Add docs/assets/js/zoom.js to handle graph zoom controls separately.

Bug Fixes:
- Fix @SuppressWarnings annotations to use quoted rule identifiers for PHPStan and PHPMD compatibility.

Enhancements:
- Decompose the IndexPage constructor into private methods (generateHtmlHeader, generateSvgContainer, generateMarkdownContent, generateHtmlContent, generateSvgHtmlContainer, generateMainScript, generateViewControls) to improve readability and maintainability.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the structure and readability of the main page by modularizing content generation and separating HTML/JavaScript blocks into dedicated methods.
  * Updated annotation syntax for static analysis suppression to use quoted strings for consistency.

* **Style**
  * Removed unnecessary suppression annotations related to method length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->