### PR TITLE
Fix Homebrew path resolution for cross-platform compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,11 +102,9 @@ The `--watch` option starts a Node.js server that monitors profile changes and r
 
 **Homebrew Installation Notes:**
 - Watch mode path resolution handles both Cellar and opt directory structures
-- Primary path: `/opt/homebrew/Cellar/asd/x.x.x/libexec/asd-sync`
-- Fallback path: `/opt/homebrew/opt/asd/libexec/asd-sync` (version-independent)
-- Both `asd -w` and `asdw` commands should work identically
+- Uses dynamic Homebrew prefix detection via `brew --prefix`
+- Supports both ARM (`/opt/homebrew`) and Intel (`/usr/local`) architectures
 
 **Troubleshooting Watch Mode:**
-- If `asd -w` fails with "No such file or directory", try `asdw` command
 - Error messages show expected path for debugging
 - Ensure Node.js dependencies are installed in the asd-sync directory

--- a/bin/asd
+++ b/bin/asd
@@ -78,9 +78,12 @@ if ($config->watch) {
         
         // Try version-independent opt path if not found in Cellar
         if (!is_dir($actualPath)) {
-            $optPath = '/opt/homebrew/opt/asd/libexec/asd-sync';
-            if (is_dir($optPath)) {
-                $actualPath = $optPath;
+            $homebrewPrefix = trim(shell_exec('brew --prefix 2>/dev/null') ?? '');
+            if ($homebrewPrefix !== '') {
+                $optPath = $homebrewPrefix . '/opt/asd/libexec/asd-sync';
+                if (is_dir($optPath)) {
+                    $actualPath = $optPath;
+                }
             }
         }
     }
@@ -88,7 +91,6 @@ if ($config->watch) {
     if (!is_dir($actualPath)) {
         echo "Error: asd-sync directory not found. Watch mode requires Node.js components.\n";
         echo "Expected path: $actualPath\n";
-        echo "Try using 'asdw' command instead if you installed via Homebrew.\n";
         exit(1);
     }
     

--- a/src/PathResolver.php
+++ b/src/PathResolver.php
@@ -7,9 +7,29 @@ namespace Koriym\AppStateDiagram;
 use Phar;
 
 use function dirname;
+use function file_exists;
+use function is_dir;
+use function shell_exec;
+use function trim;
 
 final class PathResolver
 {
+    private static function getHomebrewPrefix(): ?string
+    {
+        // @codeCoverageIgnoreStart
+        /** @psalm-suppress ForbiddenCode */
+        $prefix = shell_exec('brew --prefix 2>/dev/null');
+        if ($prefix !== null && $prefix !== false) {
+            $prefix = trim($prefix);
+            if ($prefix !== '' && is_dir($prefix)) {
+                return $prefix;
+            }
+        }
+
+        return null;
+        // @codeCoverageIgnoreEnd
+    }
+
     public static function getDotJsPath(): string
     {
         $pharRunning = Phar::running(false);
@@ -23,8 +43,20 @@ final class PathResolver
         // PHAR execution: asd-sync is in the parent directory of bin/
         $pharDir = dirname($pharRunning);
         $projectDir = dirname($pharDir);
+        $dotJsPath = $projectDir . '/asd-sync/dot.js';
 
-        return $projectDir . '/asd-sync/dot.js';
+        // Try version-independent opt path if not found in Cellar (for Homebrew)
+        if (! file_exists($dotJsPath)) {
+            $homebrewPrefix = self::getHomebrewPrefix();
+            if ($homebrewPrefix !== null) {
+                $optPath = $homebrewPrefix . '/opt/asd/libexec/asd-sync/dot.js';
+                if (file_exists($optPath)) {
+                    return $optPath;
+                }
+            }
+        }
+
+        return $dotJsPath;
         // @codeCoverageIgnoreEnd
     }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `/opt/homebrew` paths with dynamic `brew --prefix` detection
- Add fallback path resolution in `PathResolver.php` for libexec directory structure  
- Support both ARM (`/opt/homebrew`) and Intel (`/usr/local`) Mac architectures
- Remove asdw command references as path fix makes it obsolete

## Test plan

- [x] Run `composer test` - all tests pass
- [x] Run `composer sa` - no static analysis errors
- [x] Verify SVG mode works with Homebrew-installed asd
- [ ] Test on both ARM and Intel Macs (if available)

🤖 Generated with [Claude Code](https://claude.ai/code)

## Sourceryによる要約

Homebrewのパス動的解決を有効化し、ARMとIntel両方のmacOSアーキテクチャをサポート

新機能:
- `brew --prefix` を介して実行時にHomebrewのプレフィックスを検出
- Homebrew opt配下にあるバージョンに依存しないlibexecパスのフォールバック解決を追加

改善点:
- ハードコードされたパスの代わりに、`/opt/homebrew` と `/usr/local` 両方のインストールをサポート

ドキュメント:
- 動的なプレフィックス検出を反映し、廃止された `asdw` 参照を削除するようにドキュメントを更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable dynamic Homebrew path resolution and support both ARM and Intel macOS architectures

New Features:
- Detect Homebrew prefix at runtime via `brew --prefix`
- Add fallback resolution for version-independent libexec path under Homebrew opt

Enhancements:
- Support both `/opt/homebrew` and `/usr/local` installations instead of hardcoded paths

Documentation:
- Update documentation to reflect dynamic prefix detection and remove obsolete `asdw` references

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Homebrew installation notes to use dynamic prefix detection, improving compatibility with both ARM and Intel architectures.
  * Clarified troubleshooting steps and removed outdated suggestions regarding command usage.

* **Bug Fixes**
  * Improved detection of Homebrew installation paths, ensuring correct operation regardless of system architecture.
  * Enhanced fallback mechanisms for locating required files in Homebrew-managed environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->