### PR TITLE
Fix Homebrew path resolution for dot.js in SVG mode

### DIFF
--- a/bin/asd
+++ b/bin/asd
@@ -6,6 +6,7 @@ declare(strict_types=1);
 use Koriym\AppStateDiagram\ConfigFactory;
 use Koriym\AppStateDiagram\Diagram;
 use Koriym\AppStateDiagram\Exception\AlpsFileNotReadableException;
+use Koriym\AppStateDiagram\PathResolver;
 use Koriym\AppStateDiagram\PutDiagram;
 use Koriym\DataFile\Exception\DataFileNotFoundException;
 
@@ -78,8 +79,8 @@ if ($config->watch) {
         
         // Try version-independent opt path if not found in Cellar
         if (!is_dir($actualPath)) {
-            $homebrewPrefix = trim(shell_exec('brew --prefix 2>/dev/null') ?? '');
-            if ($homebrewPrefix !== '') {
+            $homebrewPrefix = PathResolver::getHomebrewPrefix();
+            if ($homebrewPrefix !== null) {
                 $optPath = $homebrewPrefix . '/opt/asd/libexec/asd-sync';
                 if (is_dir($optPath)) {
                     $actualPath = $optPath;


### PR DESCRIPTION
## Summary
- Fixes Homebrew path resolution issue when using SVG mode (`--mode=svg`)
- Improves PHAR execution path detection by checking Cellar path first
- Provides fallback to version-independent opt path for better compatibility

## Problem
When running `asd --mode=svg` with Homebrew installation, the tool was failing to find the `dot.js` file, resulting in "Cannot find module" errors. This was due to incorrect path resolution logic in the `PathResolver::getDotJsPath()` method.

## Solution
- Check Cellar path first (`/opt/homebrew/Cellar/asd/x.x.x/libexec/asd-sync/dot.js`)
- If not found, fallback to version-independent opt path (`/opt/homebrew/opt/asd/libexec/asd-sync/dot.js`)
- Maintain existing functionality for non-PHAR execution

## Test plan
- [x] Run `asd --mode=svg ./profile.xml` with local development version
- [x] Verify both SVG files are generated (`profile.svg` and `profile.title.svg`)
- [x] Run test suite to ensure no regressions
- [ ] Test with actual Homebrew installation

🤖 Generated with [Claude Code](https://claude.ai/code)

## Sourceryによる要約

SVGモードでのHomebrewインストールにおけるdot.jsのパス解決を修正し、Homebrewプレフィックス検出を改善

バグ修正点:
- SVGモードにおけるdot.jsの解決を、HomebrewのCellarディレクトリおよびoptディレクトリ内で正しく配置することで修正

改善点:
- `getHomebrewPrefix`を公開し、プレフィックスを解決する前に`brew`コマンドの利用可能性をチェックする機能を追加
- PHAR実行ロジックを更新し、HomebrewのCellarパスを優先し、次にバージョンに依存しないoptパスにフォールバックし、その後に元の場所にデフォルト設定されるように変更

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix dot.js path resolution for Homebrew installations in SVG mode and improve Homebrew prefix detection

Bug Fixes:
- Fix dot.js resolution in SVG mode by correctly locating it in Homebrew Cellar and opt directories

Enhancements:
- Expose getHomebrewPrefix publicly and add a check for brew command availability before resolving prefix
- Update PHAR execution logic to prioritize Homebrew Cellar path, then fallback to the version-independent opt path, before defaulting to the original location

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the Homebrew installation path, ensuring better compatibility and reliability when locating required files.
  * Enhanced logic for resolving the location of the `dot.js` file, increasing robustness in various installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->