### PR TITLE
Add Compact size option for diagram display

### DIFF
--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -316,6 +316,8 @@ a{cursor:pointer;}
 #svg-graph svg{display:block;max-width:none;}
 #svg-container.fit-width #svg-graph svg{max-width:100% !important;width:100% !important;height:auto !important;}
 #svg-container.fit-width #svg-graph{flex-shrink:1;width:100%;}
+#svg-container.half-size #svg-graph svg{max-width:60% !important;width:60% !important;height:auto !important;}
+#svg-container.half-size #svg-graph{flex-shrink:0;}
 h1,h2{margin-top:0;}
 /* Legend */
 .legend{display:flex;gap:20px;margin:20px 0;flex-wrap:wrap;}
@@ -673,6 +675,7 @@ document.addEventListener('DOMContentLoaded', function() {
     <div class="selector-row">
         <span class="selector-label">Size:</span>
         <span class="selector-option"><input type="radio" name="sizeMode" value="original" checked><label> Original</label></span>
+        <span class="selector-option"><input type="radio" name="sizeMode" value="half"><label> Compact</label></span>
         <span class="selector-option"><input type="radio" name="sizeMode" value="fit"><label> Fit to width</label></span>
     </div>
 ${tagSelectorHtml ? `    <div class="selector-row">${tagSelectorHtml}</div>` : ''}
@@ -865,10 +868,11 @@ document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
         const selectorTopBefore = selectorRect.top;
 
         const svgContainer = document.getElementById('svg-container');
+        svgContainer.classList.remove('fit-width', 'half-size');
         if (this.value === 'fit') {
             svgContainer.classList.add('fit-width');
-        } else {
-            svgContainer.classList.remove('fit-width');
+        } else if (this.value === 'half') {
+            svgContainer.classList.add('half-size');
         }
 
         // Adjust scroll to keep selector at same screen position (instant, no animation)
@@ -876,7 +880,7 @@ document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
             const selectorTopAfter = selector.getBoundingClientRect().top;
             const scrollDiff = selectorTopAfter - selectorTopBefore;
             window.scrollTo({ top: window.scrollY + scrollDiff, behavior: 'instant' });
-            if (this.value === 'original') {
+            if (this.value === 'original' || this.value === 'half') {
                 centerSvgScroll();
             }
         });
@@ -889,16 +893,22 @@ function autoSelectSizeMode() {
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
     const originalRadio = document.querySelector('input[name="sizeMode"][value="original"]');
+    const halfOption = document.querySelector('input[name="sizeMode"][value="half"]')?.closest('.selector-option');
 
     if (!svgContainer || !svgElement) return;
 
     // Temporarily remove fit-width to measure SVG's natural size
-    svgContainer.classList.remove('fit-width');
+    svgContainer.classList.remove('fit-width', 'half-size');
 
     // Use setTimeout to allow reflow before measuring
     setTimeout(() => {
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
+
+        // Show 50% option only when SVG is wider than container
+        if (halfOption) {
+            halfOption.style.display = svgWidth > containerWidth ? 'inline-block' : 'none';
+        }
 
         // If SVG is wider than container, auto-select Fit to width
         if (svgWidth > containerWidth) {

--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -893,7 +893,7 @@ function autoSelectSizeMode() {
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
     const originalRadio = document.querySelector('input[name="sizeMode"][value="original"]');
-    const halfOption = document.querySelector('input[name="sizeMode"][value="half"]')?.closest('.selector-option');
+    const compactOption = document.querySelector('input[name="sizeMode"][value="half"]')?.closest('.selector-option');
 
     if (!svgContainer || !svgElement) return;
 
@@ -905,9 +905,9 @@ function autoSelectSizeMode() {
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
 
-        // Show 50% option only when SVG is wider than container
-        if (halfOption) {
-            halfOption.style.display = svgWidth > containerWidth ? 'inline-block' : 'none';
+        // Show Compact option only when SVG is wider than container
+        if (compactOption) {
+            compactOption.style.display = svgWidth > containerWidth ? 'inline-block' : 'none';
         }
 
         // If SVG is wider than container, auto-select Fit to width

--- a/packages/app-state-diagram/src/generator/html-generator.ts
+++ b/packages/app-state-diagram/src/generator/html-generator.ts
@@ -87,6 +87,8 @@ a{cursor:pointer;}
 #svg-graph svg{display:block;max-width:none;}
 #svg-container.fit-width #svg-graph svg{max-width:100% !important;width:100% !important;height:auto !important;}
 #svg-container.fit-width #svg-graph{flex-shrink:1;width:100%;}
+#svg-container.half-size #svg-graph svg{max-width:60% !important;width:60% !important;height:auto !important;}
+#svg-container.half-size #svg-graph{flex-shrink:0;}
 h1,h2{margin-top:0;}
 /* Legend */
 .legend{display:flex;gap:20px;margin:20px 0;flex-wrap:wrap;}
@@ -282,6 +284,7 @@ document.addEventListener('DOMContentLoaded', function() {
     <div class="selector-row">
         <span class="selector-label">Size:</span>
         <span class="selector-option"><input type="radio" name="sizeMode" value="original" checked><label> Original</label></span>
+        <span class="selector-option"><input type="radio" name="sizeMode" value="half"><label> Compact</label></span>
         <span class="selector-option"><input type="radio" name="sizeMode" value="fit"><label> Fit to width</label></span>
     </div>
 ${tagSelectorHtml ? `    <div class="selector-row">${tagSelectorHtml}</div>` : ''}
@@ -462,10 +465,11 @@ document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
         const selectorTopBefore = selectorRect.top;
 
         const svgContainer = document.getElementById('svg-container');
+        svgContainer.classList.remove('fit-width', 'half-size');
         if (this.value === 'fit') {
             svgContainer.classList.add('fit-width');
-        } else {
-            svgContainer.classList.remove('fit-width');
+        } else if (this.value === 'half') {
+            svgContainer.classList.add('half-size');
         }
 
         // Adjust scroll to keep selector at same screen position (instant, no animation)
@@ -473,7 +477,7 @@ document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
             const selectorTopAfter = selector.getBoundingClientRect().top;
             const scrollDiff = selectorTopAfter - selectorTopBefore;
             window.scrollTo({ top: window.scrollY + scrollDiff, behavior: 'instant' });
-            if (this.value === 'original') {
+            if (this.value === 'original' || this.value === 'half') {
                 centerSvgScroll();
             }
         });
@@ -485,14 +489,20 @@ function autoSelectSizeMode() {
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
     const originalRadio = document.querySelector('input[name="sizeMode"][value="original"]');
+    const halfOption = document.querySelector('input[name="sizeMode"][value="half"]')?.closest('.selector-option');
 
     if (!svgContainer || !svgElement) return;
 
-    svgContainer.classList.remove('fit-width');
+    svgContainer.classList.remove('fit-width', 'half-size');
 
     setTimeout(() => {
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
+
+        // Show 50% option only when SVG is wider than container
+        if (halfOption) {
+            halfOption.style.display = svgWidth > containerWidth ? 'inline-block' : 'none';
+        }
 
         if (svgWidth > containerWidth) {
             svgContainer.classList.add('fit-width');

--- a/packages/app-state-diagram/src/generator/html-generator.ts
+++ b/packages/app-state-diagram/src/generator/html-generator.ts
@@ -489,7 +489,7 @@ function autoSelectSizeMode() {
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
     const originalRadio = document.querySelector('input[name="sizeMode"][value="original"]');
-    const halfOption = document.querySelector('input[name="sizeMode"][value="half"]')?.closest('.selector-option');
+    const compactOption = document.querySelector('input[name="sizeMode"][value="half"]')?.closest('.selector-option');
 
     if (!svgContainer || !svgElement) return;
 
@@ -499,9 +499,9 @@ function autoSelectSizeMode() {
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
 
-        // Show 50% option only when SVG is wider than container
-        if (halfOption) {
-            halfOption.style.display = svgWidth > containerWidth ? 'inline-block' : 'none';
+        // Show Compact option only when SVG is wider than container
+        if (compactOption) {
+            compactOption.style.display = svgWidth > containerWidth ? 'inline-block' : 'none';
         }
 
         if (svgWidth > containerWidth) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
   packages/mcp:
     dependencies:
       '@alps-asd/app-state-diagram':
-        specifier: ^0.20.2
-        version: 0.20.2
+        specifier: ^0.21.0
+        version: 0.21.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.24.3(zod@4.1.13)
@@ -89,8 +89,8 @@ importers:
 
 packages:
 
-  '@alps-asd/app-state-diagram@0.20.2':
-    resolution: {integrity: sha512-dryorbYdVs+BMjjKFQLhABuP9xwsiixoSqxmyGgT9lLai1CJUdZYThKSQNPF3kLicpQBTlS2rkZ8eVeQyMGw2g==}
+  '@alps-asd/app-state-diagram@0.21.0':
+    resolution: {integrity: sha512-csUW1adQHsIzSgMLfUQPTTcBNeOks3RjzQCxZhlaebWxIFlgls5Z92nAxs9pJA+x2LZraJ4WR07uQhqQAmL0OA==}
     hasBin: true
 
   '@babel/code-frame@7.27.1':
@@ -1780,7 +1780,7 @@ packages:
 
 snapshots:
 
-  '@alps-asd/app-state-diagram@0.20.2':
+  '@alps-asd/app-state-diagram@0.21.0':
     dependencies:
       '@viz-js/viz': 3.23.0
       commander: 11.1.0


### PR DESCRIPTION
## Summary
- Add new "Compact" size option (60% of original) between Original and Fit to width
- Only show Compact option when SVG is larger than container width
- Improves UX for viewing large diagrams at a readable intermediate size

## Changes
- `docs/js/diagramAdapters.js` - Online editor
- `packages/app-state-diagram/src/generator/html-generator.ts` - CLI generated HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Compact" view mode for diagrams with reduced width display.

* **Improvements**
  * Enhanced responsive sizing to automatically adapt diagram display based on available container space.
  * Improved auto-sizing logic to detect and select the optimal view mode for diagram presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->