### PR TITLE
Release 2.0.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-state-diagram",
-  "version": "0.1.0",
+  "version": "2.0.0-alpha.1",
   "private": true,
   "description": "ALPS (Application-Level Profile Semantics) tooling monorepo",
   "keywords": [

--- a/packages/app-state-diagram/package.json
+++ b/packages/app-state-diagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alps-asd/app-state-diagram",
-  "version": "0.21.0",
+  "version": "2.0.0-alpha.1",
   "description": "ALPS CLI tool - generate documentation from ALPS profiles",
   "main": "dist/asd.js",
   "types": "dist/asd.d.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alps-asd/mcp",
-  "version": "0.2.0",
+  "version": "2.0.0-alpha.1",
   "description": "ALPS MCP Server - Model Context Protocol server for ALPS profile tools",
   "type": "module",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@alps-asd/app-state-diagram": "^0.21.0"
+    "@alps-asd/app-state-diagram": "workspace:*"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
   packages/mcp:
     dependencies:
       '@alps-asd/app-state-diagram':
-        specifier: ^0.21.0
-        version: 0.21.0
+        specifier: workspace:*
+        version: link:../app-state-diagram
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.24.3(zod@4.1.13)
@@ -88,10 +88,6 @@ importers:
         version: 5.9.3
 
 packages:
-
-  '@alps-asd/app-state-diagram@0.21.0':
-    resolution: {integrity: sha512-csUW1adQHsIzSgMLfUQPTTcBNeOks3RjzQCxZhlaebWxIFlgls5Z92nAxs9pJA+x2LZraJ4WR07uQhqQAmL0OA==}
-    hasBin: true
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1779,18 +1775,6 @@ packages:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
 snapshots:
-
-  '@alps-asd/app-state-diagram@0.21.0':
-    dependencies:
-      '@viz-js/viz': 3.23.0
-      commander: 11.1.0
-      fast-xml-parser: 4.5.3
-    optionalDependencies:
-      chokidar: 3.6.0
-      chrome-remote-interface: 0.33.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@babel/code-frame@7.27.1':
     dependencies:


### PR DESCRIPTION
## Release 2.0.0-alpha.1

First alpha release of the TypeScript rewrite.

### Changes
- Bump all packages to 2.0.0-alpha.1
- Use workspace dependency for @alps-asd/mcp

### Packages
- `@alps-asd/app-state-diagram`: 2.0.0-alpha.1
- `@alps-asd/mcp`: 2.0.0-alpha.1

### Breaking Changes
- Complete rewrite from PHP to TypeScript
- New CLI interface

### After merge
1. Create tag `v2.0.0-alpha.1`
2. Publish to npm
3. Update Homebrew formula

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all package versions to 2.0.0-alpha.1.
  * Configured internal package dependencies to use workspace reference for improved monorepo management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->