### PR TITLE
Fix URL hash update on inline link click

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -23,7 +23,6 @@ const smoothScrollTo = (targetElement) => {
     };
 
     requestAnimationFrame(animate);
-    history.pushState(null, null, '#' + targetElement.getAttribute('name'));
 };
 
 const applySmoothScrollToLinks = (links) => {

--- a/docs/blog/alps.json
+++ b/docs/blog/alps.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://alps-io.github.io/schemas/alps.json",
+  "alps": {
+    "title": "ALPS Blog (Test)",
+    "doc": {"value": "An ALPS profile for testing remote profile loading"},
+    "descriptor": [
+      {"id": "id", "type": "semantic", "def": "https://schema.org/identifier"},
+      {"id": "articleBody", "type": "semantic", "def": "https://schema.org/articleBody"},
+      {"id": "dateCreated", "type": "semantic", "def": "https://schema.org/dateCreated"},
+
+      {"id": "About", "type": "semantic", "descriptor": [
+        {"href": "#goBlog"}
+      ]},
+      {"id": "Blog", "type": "semantic", "def": "https://schema.org/Blog", "title": "Blog post list", "descriptor": [
+        {"href": "#BlogPosting"},
+        {"href": "#goBlogPosting"},
+        {"href": "#goAbout"},
+        {"href": "#doPost"}
+      ]},
+      {"id": "BlogPosting", "type": "semantic", "title": "Blog post item", "def": "https://schema.org/BlogPosting", "descriptor": [
+        {"href": "#id"},
+        {"href": "#articleBody"},
+        {"href": "#dateCreated"},
+        {"href": "#goBlog"}
+      ]},
+
+      {"id": "goBlog", "type": "safe", "rt": "#Blog", "title": "Go to Blog"},
+      {"id": "goAbout", "type": "safe", "rt": "#About", "title": "Go to About"},
+      {"id": "goBlogPosting", "type": "safe", "rt": "#BlogPosting", "title": "Go to Blog Posting", "descriptor": [
+        {"href": "#id"}
+      ]},
+      {"id": "doPost", "type": "unsafe", "rt": "#Blog", "title": "Create Post", "descriptor": [
+        {"href": "#articleBody"}
+      ]}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Remove duplicate `history.pushState` call from `smoothScrollTo` function
- URL hash is now correctly updated only in `applySmoothScrollToLinks` using the `href` value
- Prevents potential `#null` or `#undefined` URLs when target elements don't have a `name` attribute