### PR TITLE
Fix SVG click handlers and DOT generation

### DIFF
--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -768,6 +768,12 @@ setupTagTrigger();
 // Label mode switching
 const alpsData = ${escapeJsonForScript(alpsData)};
 
+// NOTE: The escape functions below use double-escaped patterns (e.g., /\\\\\\\\/g instead of /\\\\/g)
+// because this code is embedded in a JavaScript template literal within the HTML generator.
+// The first level of escaping is consumed when the template literal is evaluated,
+// leaving the correct single-escaped patterns at runtime.
+// Compare with Alps2DotAdapter class methods which run directly and use single escaping.
+
 // Escape a string for use as a DOT ID
 function escapeDotId(id) {
     if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(id)) {

--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -423,17 +423,18 @@ document.addEventListener('keydown', function(event) {
     }
 });
 
-document.addEventListener('DOMContentLoaded', function() {
+// Setup SVG event handlers - extracted to be reusable after SVG regeneration
+function setupSvgEventHandlers() {
     // Add click handlers to all SVG elements with href="#something"
     const svgLinks = document.querySelectorAll('svg a[href^="#"], svg a[*|href^="#"]');
     console.log('Found SVG links:', svgLinks.length);
-    
+
     svgLinks.forEach(link => {
         link.addEventListener('click', function(e) {
             e.preventDefault();
             e.stopPropagation();
             console.log('SVG link clicked:', this);
-            
+
             const href = this.getAttribute('href') || this.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
             if (href && href.startsWith('#')) {
                 const id = href.substring(1);
@@ -453,6 +454,11 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Setup SVG event handlers on initial load
+    setupSvgEventHandlers();
 
     // Handle table internal links
     document.querySelectorAll('table a[href^="#"]').forEach(link => {
@@ -762,6 +768,23 @@ setupTagTrigger();
 // Label mode switching
 const alpsData = ${escapeJsonForScript(alpsData)};
 
+// Escape a string for use as a DOT ID
+function escapeDotId(id) {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(id)) {
+        return id;
+    }
+    return '"' + id.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '\\\\"') + '"';
+}
+
+// Escape a string for use as a DOT label (inside double quotes)
+function escapeDotLabel(label) {
+    return label
+        .replace(/\\\\/g, '\\\\\\\\')
+        .replace(/"/g, '\\\\"')
+        .replace(/</g, '\\\\<')
+        .replace(/>/g, '\\\\>');
+}
+
 function generateDotFromAlps(alpsData, labelMode) {
     const descriptors = alpsData.alps?.descriptor || [];
 
@@ -785,7 +808,9 @@ function generateDotFromAlps(alpsData, labelMode) {
 
     states.forEach(state => {
         if (state.id) {
-            dot += '    ' + state.id + ' [margin=0.1, label="' + getLabel(state) + '", shape=box, URL="#' + state.id + '"]\\n';
+            const nodeId = escapeDotId(state.id);
+            const nodeLabel = escapeDotLabel(getLabel(state));
+            dot += '    ' + nodeId + ' [margin=0.1, label="' + nodeLabel + '", shape=box, URL="#' + state.id + '"]\\n';
         }
     });
 
@@ -796,9 +821,11 @@ function generateDotFromAlps(alpsData, labelMode) {
             const targetState = trans.rt.replace('#', '');
             const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
             const color = getTransitionColor(trans.type);
-            const transLabel = getLabel(trans);
+            const transLabel = escapeDotLabel(getLabel(trans));
             sourceStates.forEach(sourceState => {
-                dot += '    ' + sourceState + ' -> ' + targetState + ' [label="' + transLabel + '" URL="#' + trans.id + '" fontsize=13 class="' + trans.id + '" penwidth=1.5 color="' + color + '"];\\n';
+                const srcId = escapeDotId(sourceState);
+                const tgtId = escapeDotId(targetState);
+                dot += '    ' + srcId + ' -> ' + tgtId + ' [label="' + transLabel + '" URL="#' + trans.id + '" fontsize=13 class="' + trans.id + '" penwidth=1.5 color="' + color + '"];\\n';
             });
         }
     });
@@ -806,7 +833,9 @@ function generateDotFromAlps(alpsData, labelMode) {
     dot += '\\n';
     states.forEach(state => {
         if (state.id) {
-            dot += '    ' + state.id + ' [label="' + getLabel(state) + '" URL="#' + state.id + '"]\\n';
+            const nodeId = escapeDotId(state.id);
+            const nodeLabel = escapeDotLabel(getLabel(state));
+            dot += '    ' + nodeId + ' [label="' + nodeLabel + '" URL="#' + state.id + '"]\\n';
         }
     });
     dot += '\\n}';
@@ -848,6 +877,8 @@ async function regenerateSvg(labelMode) {
         const svgString = await vizInstance.renderString(dotContent, { format: 'svg' });
         svgGraph.innerHTML = svgString;
         console.log('SVG regenerated with labelMode:', labelMode);
+        // Re-attach SVG event handlers after regeneration
+        setupSvgEventHandlers();
     } catch (error) {
         console.error('Error regenerating SVG:', error);
         svgGraph.innerHTML = '<p style="color:red;">Error regenerating diagram: ' + error.message + '</p>';
@@ -1056,6 +1087,23 @@ window.addEventListener('resize', autoSelectSizeMode);
         return result;
     }
 
+    // Escape a string for use as a DOT ID
+    escapeDotId(id) {
+        if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(id)) {
+            return id;
+        }
+        return '"' + id.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+    }
+
+    // Escape a string for use as a DOT label (inside double quotes)
+    escapeDotLabel(label) {
+        return label
+            .replace(/\\/g, '\\\\')
+            .replace(/"/g, '\\"')
+            .replace(/</g, '\\<')
+            .replace(/>/g, '\\>');
+    }
+
     generateDotFromAlps(alpsData, labelMode = 'id') {
         const descriptors = alpsData.alps?.descriptor || [];
 
@@ -1089,7 +1137,9 @@ window.addEventListener('resize', autoSelectSizeMode);
         // Add state nodes
         states.forEach(state => {
             if (state.id) {
-                dot += `    ${state.id} [margin=0.1, label="${getLabel(state)}", shape=box, URL="#${state.id}"]\n`;
+                const nodeId = this.escapeDotId(state.id);
+                const nodeLabel = this.escapeDotLabel(getLabel(state));
+                dot += `    ${nodeId} [margin=0.1, label="${nodeLabel}", shape=box, URL="#${state.id}"]\n`;
             }
         });
 
@@ -1103,10 +1153,12 @@ window.addEventListener('resize', autoSelectSizeMode);
 
                 sourceStates.forEach(sourceState => {
                     const color = this.getTransitionColor(trans.type);
-                    const transLabel = getLabel(trans);
+                    const transLabel = this.escapeDotLabel(getLabel(trans));
+                    const srcId = this.escapeDotId(sourceState);
+                    const tgtId = this.escapeDotId(targetState);
 
                     // Color-coded edges without symbol
-                    dot += `    ${sourceState} -> ${targetState} [label="${transLabel}" URL="#${trans.id}" fontsize=13 class="${trans.id}" penwidth=1.5 color="${color}"];\n`;
+                    dot += `    ${srcId} -> ${tgtId} [label="${transLabel}" URL="#${trans.id}" fontsize=13 class="${trans.id}" penwidth=1.5 color="${color}"];\n`;
                 });
             }
         });
@@ -1116,7 +1168,9 @@ window.addEventListener('resize', autoSelectSizeMode);
         // Add basic state nodes again (for compatibility)
         states.forEach(state => {
             if (state.id) {
-                dot += `    ${state.id} [label="${getLabel(state)}" URL="#${state.id}"]\n`;
+                const nodeId = this.escapeDotId(state.id);
+                const nodeLabel = this.escapeDotLabel(getLabel(state));
+                dot += `    ${nodeId} [label="${nodeLabel}" URL="#${state.id}"]\n`;
             }
         });
 

--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -780,9 +780,14 @@ function escapeDotId(id) {
 function escapeDotLabel(label) {
     return label
         .replace(/\\\\/g, '\\\\\\\\')
-        .replace(/"/g, '\\\\"')
-        .replace(/</g, '\\\\<')
-        .replace(/>/g, '\\\\>');
+        .replace(/"/g, '\\\\"');
+}
+
+// Escape a string for use in a DOT attribute value (inside double quotes)
+function escapeDotAttr(value) {
+    return value
+        .replace(/\\\\/g, '\\\\\\\\')
+        .replace(/"/g, '\\\\"');
 }
 
 function generateDotFromAlps(alpsData, labelMode) {
@@ -810,7 +815,8 @@ function generateDotFromAlps(alpsData, labelMode) {
         if (state.id) {
             const nodeId = escapeDotId(state.id);
             const nodeLabel = escapeDotLabel(getLabel(state));
-            dot += '    ' + nodeId + ' [margin=0.1, label="' + nodeLabel + '", shape=box, URL="#' + state.id + '"]\\n';
+            const nodeUrl = escapeDotAttr('#' + state.id);
+            dot += '    ' + nodeId + ' [margin=0.1, label="' + nodeLabel + '", shape=box, URL="' + nodeUrl + '"]\\n';
         }
     });
 
@@ -822,10 +828,12 @@ function generateDotFromAlps(alpsData, labelMode) {
             const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
             const color = getTransitionColor(trans.type);
             const transLabel = escapeDotLabel(getLabel(trans));
+            const transUrl = escapeDotAttr('#' + trans.id);
+            const transClass = escapeDotAttr(trans.id);
             sourceStates.forEach(sourceState => {
                 const srcId = escapeDotId(sourceState);
                 const tgtId = escapeDotId(targetState);
-                dot += '    ' + srcId + ' -> ' + tgtId + ' [label="' + transLabel + '" URL="#' + trans.id + '" fontsize=13 class="' + trans.id + '" penwidth=1.5 color="' + color + '"];\\n';
+                dot += '    ' + srcId + ' -> ' + tgtId + ' [label="' + transLabel + '" URL="' + transUrl + '" fontsize=13 class="' + transClass + '" penwidth=1.5 color="' + color + '"];\\n';
             });
         }
     });
@@ -835,7 +843,8 @@ function generateDotFromAlps(alpsData, labelMode) {
         if (state.id) {
             const nodeId = escapeDotId(state.id);
             const nodeLabel = escapeDotLabel(getLabel(state));
-            dot += '    ' + nodeId + ' [label="' + nodeLabel + '" URL="#' + state.id + '"]\\n';
+            const nodeUrl = escapeDotAttr('#' + state.id);
+            dot += '    ' + nodeId + ' [label="' + nodeLabel + '" URL="' + nodeUrl + '"]\\n';
         }
     });
     dot += '\\n}';
@@ -1099,9 +1108,14 @@ window.addEventListener('resize', autoSelectSizeMode);
     escapeDotLabel(label) {
         return label
             .replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/</g, '\\<')
-            .replace(/>/g, '\\>');
+            .replace(/"/g, '\\"');
+    }
+
+    // Escape a string for use in a DOT attribute value (inside double quotes)
+    escapeDotAttr(value) {
+        return value
+            .replace(/\\/g, '\\\\')
+            .replace(/"/g, '\\"');
     }
 
     generateDotFromAlps(alpsData, labelMode = 'id') {
@@ -1139,7 +1153,8 @@ window.addEventListener('resize', autoSelectSizeMode);
             if (state.id) {
                 const nodeId = this.escapeDotId(state.id);
                 const nodeLabel = this.escapeDotLabel(getLabel(state));
-                dot += `    ${nodeId} [margin=0.1, label="${nodeLabel}", shape=box, URL="#${state.id}"]\n`;
+                const nodeUrl = this.escapeDotAttr(`#${state.id}`);
+                dot += `    ${nodeId} [margin=0.1, label="${nodeLabel}", shape=box, URL="${nodeUrl}"]\n`;
             }
         });
 
@@ -1154,11 +1169,13 @@ window.addEventListener('resize', autoSelectSizeMode);
                 sourceStates.forEach(sourceState => {
                     const color = this.getTransitionColor(trans.type);
                     const transLabel = this.escapeDotLabel(getLabel(trans));
+                    const transUrl = this.escapeDotAttr(`#${trans.id}`);
+                    const transClass = this.escapeDotAttr(trans.id);
                     const srcId = this.escapeDotId(sourceState);
                     const tgtId = this.escapeDotId(targetState);
 
                     // Color-coded edges without symbol
-                    dot += `    ${srcId} -> ${tgtId} [label="${transLabel}" URL="#${trans.id}" fontsize=13 class="${trans.id}" penwidth=1.5 color="${color}"];\n`;
+                    dot += `    ${srcId} -> ${tgtId} [label="${transLabel}" URL="${transUrl}" fontsize=13 class="${transClass}" penwidth=1.5 color="${color}"];\n`;
                 });
             }
         });
@@ -1170,7 +1187,8 @@ window.addEventListener('resize', autoSelectSizeMode);
             if (state.id) {
                 const nodeId = this.escapeDotId(state.id);
                 const nodeLabel = this.escapeDotLabel(getLabel(state));
-                dot += `    ${nodeId} [label="${nodeLabel}" URL="#${state.id}"]\n`;
+                const nodeUrl = this.escapeDotAttr(`#${state.id}`);
+                dot += `    ${nodeId} [label="${nodeLabel}" URL="${nodeUrl}"]\n`;
             }
         });
 

--- a/packages/app-state-diagram/src/generator/dot-generator.test.ts
+++ b/packages/app-state-diagram/src/generator/dot-generator.test.ts
@@ -412,4 +412,18 @@ describe('DotGenerator', () => {
     expect(map.childrenOf).toEqual({});
   });
 
+  it('should escape IDs with special characters', () => {
+    const alps: AlpsDocument = {
+      alps: {
+        descriptor: [
+          { id: 'my-state' }, // contains hyphen
+          { id: 'goToState', type: 'safe', rt: '#my-state' }
+        ]
+      }
+    };
+    const dot = generateDot(alps);
+    // ID should be quoted because it contains a hyphen
+    expect(dot).toContain('"my-state"');
+  });
+
 });

--- a/packages/app-state-diagram/src/generator/dot-generator.ts
+++ b/packages/app-state-diagram/src/generator/dot-generator.ts
@@ -10,6 +10,32 @@ import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
 export type LabelMode = 'id' | 'title';
 
 /**
+ * Escape a string for use as a DOT ID.
+ * DOT IDs need quoting if they contain special characters.
+ * Returns the ID quoted if necessary.
+ */
+function escapeDotId(id: string): string {
+  // If ID is alphanumeric with underscores only, no quoting needed
+  if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(id)) {
+    return id;
+  }
+  // Otherwise, quote it and escape internal quotes/backslashes
+  return `"${id.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Escape a string for use as a DOT label (inside double quotes).
+ * Escapes backslashes, double quotes, and angle brackets.
+ */
+function escapeDotLabel(label: string): string {
+  return label
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/</g, '\\<')
+    .replace(/>/g, '\\>');
+}
+
+/**
  * Generate DOT content from ALPS data
  */
 export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id'): string {
@@ -47,7 +73,9 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
   // Add state nodes
   for (const state of states) {
     // state.id is guaranteed by the filter above
-    dot += `    ${state.id} [margin=0.1, label="${getLabel(state)}", shape=box, URL="#${state.id}"]\n`;
+    const nodeId = escapeDotId(state.id!);
+    const nodeLabel = escapeDotLabel(getLabel(state));
+    dot += `    ${nodeId} [margin=0.1, label="${nodeLabel}", shape=box, URL="#${state.id}"]\n`;
   }
 
   dot += '\n';
@@ -59,10 +87,12 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
       const targetState = trans.rt!.replace('#', '');
       const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
       const color = getTransitionColor(trans.type);
-      const transLabel = getLabel(trans);
+      const transLabel = escapeDotLabel(getLabel(trans));
 
       for (const sourceState of sourceStates) {
-        dot += `    ${sourceState} -> ${targetState} [label="${transLabel}" URL="#${trans.id}" fontsize=13 class="${trans.id}" penwidth=1.5 color="${color}"];\n`;
+        const srcId = escapeDotId(sourceState);
+        const tgtId = escapeDotId(targetState);
+        dot += `    ${srcId} -> ${tgtId} [label="${transLabel}" URL="#${trans.id}" fontsize=13 class="${trans.id}" penwidth=1.5 color="${color}"];\n`;
       }
     }
   }
@@ -72,7 +102,9 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
   // Add basic state nodes again (for compatibility)
   for (const state of states) {
     // state.id is guaranteed by the filter above
-    dot += `    ${state.id} [label="${getLabel(state)}" URL="#${state.id}"]\n`;
+    const nodeId = escapeDotId(state.id!);
+    const nodeLabel = escapeDotLabel(getLabel(state));
+    dot += `    ${nodeId} [label="${nodeLabel}" URL="#${state.id}"]\n`;
   }
 
   dot += '\n}';

--- a/packages/app-state-diagram/src/generator/dot-generator.ts
+++ b/packages/app-state-diagram/src/generator/dot-generator.ts
@@ -25,14 +25,22 @@ function escapeDotId(id: string): string {
 
 /**
  * Escape a string for use as a DOT label (inside double quotes).
- * Escapes backslashes, double quotes, and angle brackets.
+ * Escapes backslashes and double quotes.
  */
 function escapeDotLabel(label: string): string {
   return label
     .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/</g, '\\<')
-    .replace(/>/g, '\\>');
+    .replace(/"/g, '\\"');
+}
+
+/**
+ * Escape a string for use in a DOT attribute value (inside double quotes).
+ * Same as escapeDotLabel - escapes backslashes and double quotes.
+ */
+function escapeDotAttr(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"');
 }
 
 /**
@@ -75,7 +83,8 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
     // state.id is guaranteed by the filter above
     const nodeId = escapeDotId(state.id!);
     const nodeLabel = escapeDotLabel(getLabel(state));
-    dot += `    ${nodeId} [margin=0.1, label="${nodeLabel}", shape=box, URL="#${state.id}"]\n`;
+    const nodeUrl = escapeDotAttr(`#${state.id}`);
+    dot += `    ${nodeId} [margin=0.1, label="${nodeLabel}", shape=box, URL="${nodeUrl}"]\n`;
   }
 
   dot += '\n';
@@ -88,11 +97,13 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
       const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
       const color = getTransitionColor(trans.type);
       const transLabel = escapeDotLabel(getLabel(trans));
+      const transUrl = escapeDotAttr(`#${trans.id}`);
+      const transClass = escapeDotAttr(trans.id);
 
       for (const sourceState of sourceStates) {
         const srcId = escapeDotId(sourceState);
         const tgtId = escapeDotId(targetState);
-        dot += `    ${srcId} -> ${tgtId} [label="${transLabel}" URL="#${trans.id}" fontsize=13 class="${trans.id}" penwidth=1.5 color="${color}"];\n`;
+        dot += `    ${srcId} -> ${tgtId} [label="${transLabel}" URL="${transUrl}" fontsize=13 class="${transClass}" penwidth=1.5 color="${color}"];\n`;
       }
     }
   }
@@ -104,7 +115,8 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
     // state.id is guaranteed by the filter above
     const nodeId = escapeDotId(state.id!);
     const nodeLabel = escapeDotLabel(getLabel(state));
-    dot += `    ${nodeId} [label="${nodeLabel}" URL="#${state.id}"]\n`;
+    const nodeUrl = escapeDotAttr(`#${state.id}`);
+    dot += `    ${nodeId} [label="${nodeLabel}" URL="${nodeUrl}"]\n`;
   }
 
   dot += '\n}';


### PR DESCRIPTION
- Extract setupSvgEventHandlers() and call it after regenerateSvg() to persist event handlers through SVG regeneration
- Add escapeDotId() and escapeDotLabel() functions to properly escape special characters in DOT output
- Apply escaping to both dot-generator.ts and diagramAdapters.js

Closes #240 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diagrams now escape identifiers, labels, classes and URLs so diagrams render reliably with special characters.
  * SVG event handlers are reattached after diagram regeneration to restore interactivity.

* **Refactor**
  * Initialization and SVG event wiring consolidated into a dedicated setup flow for clearer lifecycle handling.

* **Tests**
  * Added a test to verify IDs with special characters are properly escaped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->