### PR TITLE
Add alps2mock skill and Semantic First Design article

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ asd profile.json --validate
 
 See [live demos](docs/demo/) or visit [app-state-diagram.com](https://www.app-state-diagram.com/app-state-diagram/)
 
+## Mock Generation
+
+Generate a browsable HTML mock site from an ALPS profile. Every CSS class in the HTML is an ALPS descriptor ID — zero presentation classes. Switch between bare HTML, wireframe, and production quality by changing one CSS file.
+
+```
+alps.xml → html/ + css/level{1,2,3}.css + api/ + i18n/
+```
+
+See [AI Integration Guide](https://www.app-state-diagram.com/app-state-diagram/ai-integration.html) for setup (requires `alps2mock` skill).
+
 ## Design Application with AI
 
 See [AI Integration Guide](https://www.app-state-diagram.com/app-state-diagram/ai-integration.html) for setting up Claude Code, MCP Server, or other AI tools.

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -31,18 +31,25 @@ npm install -g @alps-asd/cli
 ```bash
 claude --version  # Requires 1.0.3+
 
+# ALPS profile creation & validation
 mkdir -p .claude/skills/alps
 curl -o .claude/skills/alps/SKILL.md \
-  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/.claude/skills/alps/SKILL.md
+  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/docs/skills/alps/SKILL.md
+
+# Mock generation (optional)
+mkdir -p .claude/skills/mock
+curl -o .claude/skills/mock/SKILL.md \
+  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/docs/skills/mock/SKILL.md
 ```
 
-Verify skill is available:
+Verify skills are available:
 - Ask: "What skills are available?"
-- Response should include "alps" skill
+- Response should include "alps" and "alps2mock" skills
 
 Then ask:
-- "Use the ALPS skill to create an ALPS JSON file for a blog system"
+- "Use the ALPS skill to create an ALPS XML file for a blog system"
 - "Validate alps.xml and fix any issues"
+- "Generate a mock from alps.xml" (requires alps2mock skill)
 
 ## MCP Server
 
@@ -103,6 +110,38 @@ Add to your system prompt or AGENTS.md:
 ```text
 For ALPS profile creation, refer to: https://alps-asd.github.io/app-state-diagram/alps-skill.md
 ```
+
+## Mock Generation (alps2mock)
+
+Generate a browsable HTML mock site from an ALPS profile — with zero presentation classes.
+
+```bash
+mkdir -p .claude/skills/mock
+curl -o .claude/skills/mock/SKILL.md \
+  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/docs/skills/mock/SKILL.md
+```
+
+Then ask:
+- "Use the mock skill to generate a mock from alps.xml"
+- "Generate a wireframe from my ALPS profile"
+
+### What It Generates
+
+```
+output/
+├── html/          # One page per ALPS state (semantic classes only)
+├── css/
+│   ├── level1.css # Bare HTML
+│   ├── level2.css # Wireframe — hover to see ALPS IDs
+│   └── level3.css # Production quality
+├── api/           # HAL+JSON mock responses
+├── i18n/          # ALPS ID → label mapping
+└── mock-switch    # Switch fidelity: ./mock-switch 3
+```
+
+The key idea: every `class` in HTML is an ALPS descriptor ID. No `bg-white`, no `rounded-lg`. CSS-only fidelity switching — change the `<link>` tag, HTML untouched.
+
+See [Semantic First Design](blog/semantic-first-design.md) for the design philosophy.
 
 ## Why ALPS First?
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -31,25 +31,18 @@ npm install -g @alps-asd/cli
 ```bash
 claude --version  # Requires 1.0.3+
 
-# ALPS profile creation & validation
 mkdir -p .claude/skills/alps
 curl -o .claude/skills/alps/SKILL.md \
-  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/docs/skills/alps/SKILL.md
-
-# Mock generation (optional)
-mkdir -p .claude/skills/mock
-curl -o .claude/skills/mock/SKILL.md \
-  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/docs/skills/mock/SKILL.md
+  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/.claude/skills/alps/SKILL.md
 ```
 
-Verify skills are available:
+Verify skill is available:
 - Ask: "What skills are available?"
-- Response should include "alps" and "alps2mock" skills
+- Response should include "alps" skill
 
 Then ask:
-- "Use the ALPS skill to create an ALPS XML file for a blog system"
+- "Use the ALPS skill to create an ALPS JSON file for a blog system"
 - "Validate alps.xml and fix any issues"
-- "Generate a mock from alps.xml" (requires alps2mock skill)
 
 ## MCP Server
 
@@ -110,38 +103,6 @@ Add to your system prompt or AGENTS.md:
 ```text
 For ALPS profile creation, refer to: https://alps-asd.github.io/app-state-diagram/alps-skill.md
 ```
-
-## Mock Generation (alps2mock)
-
-Generate a browsable HTML mock site from an ALPS profile — with zero presentation classes.
-
-```bash
-mkdir -p .claude/skills/mock
-curl -o .claude/skills/mock/SKILL.md \
-  https://raw.githubusercontent.com/alps-asd/app-state-diagram/2.x/docs/skills/mock/SKILL.md
-```
-
-Then ask:
-- "Use the mock skill to generate a mock from alps.xml"
-- "Generate a wireframe from my ALPS profile"
-
-### What It Generates
-
-```
-output/
-├── html/          # One page per ALPS state (semantic classes only)
-├── css/
-│   ├── level1.css # Bare HTML
-│   ├── level2.css # Wireframe — hover to see ALPS IDs
-│   └── level3.css # Production quality
-├── api/           # HAL+JSON mock responses
-├── i18n/          # ALPS ID → label mapping
-└── mock-switch    # Switch fidelity: ./mock-switch 3
-```
-
-The key idea: every `class` in HTML is an ALPS descriptor ID. No `bg-white`, no `rounded-lg`. CSS-only fidelity switching — change the `<link>` tag, HTML untouched.
-
-See [Semantic First Design](blog/semantic-first-design.md) for the design philosophy.
 
 ## Why ALPS First?
 

--- a/docs/blog/semantic-first-design.md
+++ b/docs/blog/semantic-first-design.md
@@ -1,0 +1,339 @@
+# Semantic First Design — Reuniting Meaning and Presentation in the Age of AI
+
+## The Lost Promise of Separation
+
+In the mid-1990s, the W3C established a foundational principle: **separate content from presentation**. HTML would carry meaning; CSS would carry design. The two would evolve independently.
+
+[CSS Zen Garden](http://www.csszengarden.com/) (2003) proved it was possible. The same HTML, radically different designs — hundreds of them — all achieved by swapping a single stylesheet. It was a triumph of the principle.
+
+But practice drifted. Bootstrap introduced `.col-md-6` and `.btn-primary`. BEM gave us `.block__element--modifier`. And then Tailwind's utility-first approach moved design entirely back into HTML:
+
+```html
+<article class="px-4 py-2 bg-blue-500 rounded-lg shadow-sm text-white font-medium">
+```
+
+The `class` attribute became CSS's servant, not content's identifier. The 30-year-old principle was forgotten, not disproven.
+
+## Microformats and the Semantic Class
+
+Microformats (2004) showed another path. `class="h-card"`, `class="p-name"` — class as semantic marker. These names described *what the data was*, not how it looked.
+
+Schema.org continued with Microdata (`itemprop="name"`), but left `class` to designers. The semantic web and the visual web diverged into parallel tracks.
+
+These approaches were partial. They had no formal contract binding class names to a profile definition. No machine-discoverable schema that said: "these are ALL the semantic terms this document uses, and here is what each one means."
+
+## ALPS and the Semantic Contract
+
+[ALPS](http://alps.io/) (Application-Level Profile Semantics) provides that formal contract. Per [§2.3.1 of the specification](http://alps.io/spec/alps/spec.html), descriptor IDs map directly to HTML `class` attributes.
+
+An ALPS profile defines three layers that become visible in HTML:
+
+**Ontology** — what the data IS:
+
+```html
+<h3 class="title">The Art of Programming</h3>
+<p class="author">Jane Smith</p>
+<p class="price">¥2,480</p>
+```
+
+**Taxonomy** — how things are organized:
+
+```html
+<article class="Book">
+  <!-- contains title, author, price... -->
+</article>
+```
+
+**Choreography** — what actions are possible:
+
+```html
+<a class="goToBookDetails" href="book.html?id=BK-001">View Details</a>
+<form class="doAddToCart" method="post" action="shoppingcart.html">
+```
+
+The HTML declares its semantic contract in the `<head>`:
+
+```html
+<link rel="profile" href="../profile/alps.xml">
+```
+
+Unlike Microformats or Schema.org, ALPS provides a formal, machine-discoverable profile that covers vocabulary, structure, AND transitions — the complete application semantics.
+
+## The Practice: Zero Presentation Classes
+
+Here is what this looks like in practice. Consider a book listing:
+
+**Before** — utility-class-laden HTML:
+
+```html
+<article class="Book bg-white rounded-lg shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow">
+  <h3 class="title text-lg font-semibold text-gray-900 mb-1">The Art of Programming</h3>
+  <p class="author text-sm text-gray-500 font-light mb-3">Jane Smith</p>
+  <p class="price text-sm text-gray-700 font-medium tracking-wide">¥2,480</p>
+  <a href="book.html?id=BK-001" class="goToBookDetails mt-4 inline-block text-xs uppercase tracking-widest text-gray-500 border-b border-gray-300">View Details</a>
+</article>
+```
+
+**After** — ALPS-only HTML:
+
+```html
+<article class="Book">
+  <h3 class="title">The Art of Programming</h3>
+  <p class="author">Jane Smith</p>
+  <p class="price">¥2,480</p>
+  <a href="book.html?id=BK-001" class="goToBookDetails">View Details</a>
+</article>
+```
+
+Every class in the HTML is an ALPS descriptor ID — nothing else. No `bg-white`, no `rounded-lg`, no `text-sm`. The HTML carries only meaning.
+
+CSS targets these semantic classes as selectors:
+
+```css
+.Book .title {
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.Book .author {
+  font-size: 0.875rem;
+  color: var(--brand-400);
+  font-weight: 300;
+}
+
+.Book .goToBookDetails {
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-bottom: 1px solid var(--brand-300);
+}
+```
+
+Layout uses structural selectors rather than presentation classes:
+
+```css
+/* Not: .book-grid { display: grid; } */
+.Catalog > div {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
+}
+```
+
+The cost: CSS selectors are slightly longer. The gain: HTML becomes a stable semantic document that any machine — browser, screen reader, AI agent, or API client — can understand without parsing CSS class heuristics. A screen reader navigating `.Book > .title` encounters meaning directly; no `aria-label` hacks needed to compensate for `<div class="flex items-center gap-2">`.
+
+## CSS-Only Fidelity Switching
+
+With zero presentation classes in HTML, something remarkable becomes possible: **CSS-only fidelity switching**. Three CSS files, one HTML:
+
+**`level1.css`** — bare readability. A GitHub Pages-like rendering with minimal styling:
+
+```css
+body {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+}
+a { color: #0366d6; }
+```
+
+**`level2.css`** — wireframe. The skeleton of information architecture:
+
+```css
+section, article, aside {
+  border: 1px dashed #ddd;
+  padding: 1rem;
+  margin: 0.75rem 0;
+}
+```
+
+**`level3.css`** — production quality. A polished bookstore with custom typography, warm color palette, and refined spacing:
+
+```css
+.Book .title {
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-weight: 500;
+}
+
+.doAddToCart {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+```
+
+To switch fidelity, change one attribute in the `<link>` tag:
+
+```html
+<!-- Wireframe -->
+<link rel="stylesheet" href="../css/level2.css">
+
+<!-- Production -->
+<link rel="stylesheet" href="../css/level3.css">
+```
+
+HTML untouched. Or use the `mock-switch` CLI:
+
+```bash
+./mock-switch 3 /tmp/mock   # Switch all HTML files to level3.css
+```
+
+```bash
+#!/bin/bash
+# mock-switch — Switch mock fidelity level
+level=$1
+dir=${2:-.}
+for f in "$dir"/html/*.html; do
+  sed -i '' "s|level[0-9]\.css|level${level}.css|g" "$f"
+done
+```
+
+This is CSS Zen Garden's proof, 20 years later, with a formal semantic contract backing it. The same HTML renders as a bare document, a structural wireframe, or a polished storefront — because the HTML never carried design to begin with.
+
+## The Wireframe as Profile Browser
+
+The most surprising discovery: **`level2.css` becomes a visual ALPS browser**.
+
+The key technique — a single CSS rule that reveals ALPS descriptor IDs on hover:
+
+```css
+[class]:hover::after {
+  content: "." attr(class);
+  position: absolute;
+  top: -1.25rem;
+  left: 0;
+  font-size: 0.5625rem;
+  font-family: 'SF Mono', Menlo, Consolas, monospace !important;
+  color: #fff;
+  background: #555;
+  padding: 0.125rem 0.375rem;
+  border-radius: 2px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+```
+
+Hover over any element and a tooltip appears: `.Book`, `.title`, `.goToBookDetails`, `.doAddToCart`. The ALPS vocabulary becomes *visible* in the browser.
+
+Dashed borders visualize block boundaries. X-box placeholders mark image positions:
+
+```css
+/* Block structure */
+section, article, aside {
+  border: 1px dashed #ddd;
+}
+
+/* X-box image placeholder */
+.Book > div:first-child {
+  width: 80px;
+  height: 100px;
+  background: #eee;
+  background-image:
+    linear-gradient(to top right, transparent calc(50% - 1px), #ccc, transparent calc(50% + 1px)),
+    linear-gradient(to top left, transparent calc(50% - 1px), #ccc, transparent calc(50% + 1px));
+  font-size: 0;
+}
+```
+
+`.Category` containing `.Book` articles — the nested semantic structure appears on mouseover. Designers see the skeleton of information architecture before adding any visual design. This is the bridge between information design and visual design.
+
+## Why Skeletons Matter When AI Generates Infinitely
+
+AI can generate unlimited UI variations — beautiful, polished, pixel-perfect. Give it a prompt and it will produce a stunning bookstore in seconds.
+
+But without a skeleton, AI generates from imagination, not from architecture.
+
+The semantic HTML IS the skeleton: it defines what exists, what relates to what, what actions are possible. Consider the catalog page:
+
+```html
+<main>
+  <h1 class="Catalog">The Collection</h1>
+
+  <form method="get" action="catalog.html" class="goSearchBooks">
+    <input type="text" name="query" class="query" placeholder="Search…">
+    <button type="submit">Search</button>
+  </form>
+
+  <nav>
+    <a href="category.html?id=CAT-001" class="goToCategory">Programming</a>
+    <a href="category.html?id=CAT-002" class="goToCategory">Software Design</a>
+  </nav>
+
+  <div>
+    <article class="Book">
+      <h3 class="title">The Art of Programming</h3>
+      <p class="author">Jane Smith</p>
+      <p class="price">¥2,480</p>
+      <a href="book.html?id=BK-001" class="goToBookDetails">View Details</a>
+    </article>
+  </div>
+</main>
+```
+
+This HTML is generated from the ALPS profile. Every class, every structure, every link target corresponds to a descriptor in the profile. AI fills in the flesh (CSS), but the bones (HTML + ALPS) come from human design decisions.
+
+The level 2 wireframe makes this skeleton visible and reviewable *before* any flesh is added. The ALPS profile is the blueprint; the semantic HTML is the frame; CSS is the finish.
+
+## Accessibility as a Natural Consequence
+
+We noted earlier that screen readers benefit from semantic classes. This deserves deeper examination, because the implications go beyond convenience.
+
+When HTML contains only semantic meaning, accessibility isn't an afterthought bolted on with ARIA — it's a structural property of the document itself. Screen readers encounter `.Book > .title`, `.price`, `.doAddToCart` — a complete, navigable information architecture, not a maze of layout primitives.
+
+The ALPS profile doubles as an accessibility specification: it defines what every element means, what actions are available, and how states connect.
+
+```html
+<!-- Meaningless to assistive technology -->
+<div class="flex items-center gap-2">
+  <div class="text-sm font-medium text-gray-900">The Art of Programming</div>
+  <div class="text-xs text-gray-500">Jane Smith</div>
+</div>
+
+<!-- Self-documenting -->
+<article class="Book">
+  <h3 class="title">The Art of Programming</h3>
+  <p class="author">Jane Smith</p>
+</article>
+```
+
+Semantic HTML + structural CSS = the most screen-reader-friendly architecture possible. What's good for machines reading meaning is good for assistive technology reading meaning.
+
+## The Stability of Meaning, The Flexibility of Design
+
+Domain semantics change slowly. "Book", "Author", "Price" endure across redesigns. These concepts are stable because they reflect the problem domain, not the current design trend.
+
+Design changes fast. Colors, typography, layout shift with trends, A/B tests, and brand refreshes. Last year's rounded corners become this year's sharp edges.
+
+Semantic First puts the stable thing (meaning) in HTML and the volatile thing (design) in CSS. This is not just separation of concerns — it's **separation by rate of change**.
+
+Redesign = new CSS file. HTML untouched. ALPS contract honored.
+
+The same HTML serves:
+- Wireframe reviews (level 2)
+- Design iterations (level 3, 3b, 3c...)
+- Production deploy
+- AI consumption (semantic classes are machine-readable)
+- Accessibility audits (structure is self-documenting)
+- API responses (the same semantics drive hypermedia APIs)
+
+## Conclusion: Back to the Future
+
+The W3C's 30-year-old principle was right: separate content from presentation.
+
+CSS Zen Garden proved it was possible. Microformats showed `class` could carry meaning. ALPS formalized the semantic contract with a machine-discoverable profile that binds vocabulary to structure to transitions.
+
+AI makes the skeleton essential. Without it, generation is untethered — beautiful but architecturally arbitrary. With an ALPS profile backing the HTML, AI generates *within* the semantic contract, producing CSS that respects the information architecture rather than inventing its own.
+
+Accessibility makes it ethical. Semantic HTML serves everyone — sighted users, screen reader users, and machines alike.
+
+Semantic First Design isn't new. It's the original web, rediscovered with better tools.
+
+---
+
+*The examples in this article are generated from an [ALPS profile](http://alps.io/) for a bookstore application. The HTML, CSS, and profile are available at [app-state-diagram](https://github.com/alps-asd/app-state-diagram).*

--- a/docs/blog/semantic-first-design.md
+++ b/docs/blog/semantic-first-design.md
@@ -123,7 +123,7 @@ Layout uses structural selectors rather than presentation classes:
 }
 ```
 
-The cost: CSS selectors are slightly longer. The gain: HTML becomes a stable semantic document that any machine — browser, screen reader, AI agent, or API client — can understand without parsing CSS class heuristics. A screen reader navigating `.Book > .title` encounters meaning directly; no `aria-label` hacks needed to compensate for `<div class="flex items-center gap-2">`.
+The cost: CSS selectors are slightly longer. The gain: HTML becomes a stable semantic document that any machine — browser, AI agent, or API client — can understand without parsing CSS class heuristics. A screen reader navigating `<article>` → `<h3>` → `<p>` encounters native semantic elements directly; no `aria-label` hacks needed to compensate for `<div class="flex items-center gap-2">`.
 
 ## CSS-Only Fidelity Switching
 
@@ -190,7 +190,8 @@ HTML untouched. Or use the `mock-switch` CLI:
 level=$1
 dir=${2:-.}
 for f in "$dir"/html/*.html; do
-  sed -i '' "s|level[0-9]\.css|level${level}.css|g" "$f"
+  tmp=$(mktemp)
+  sed "s|level[0-9]\.css|level${level}.css|g" "$f" > "$tmp" && mv "$tmp" "$f"
 done
 ```
 
@@ -282,9 +283,9 @@ The level 2 wireframe makes this skeleton visible and reviewable *before* any fl
 
 ## Accessibility as a Natural Consequence
 
-We noted earlier that screen readers benefit from semantic classes. This deserves deeper examination, because the implications go beyond convenience.
+We noted earlier that semantic HTML benefits screen readers. This deserves deeper examination, because the implications go beyond convenience.
 
-When HTML contains only semantic meaning, accessibility isn't an afterthought bolted on with ARIA — it's a structural property of the document itself. Screen readers encounter `.Book > .title`, `.price`, `.doAddToCart` — a complete, navigable information architecture, not a maze of layout primitives.
+When HTML contains only semantic elements — `<article>`, `<h3>`, `<p>`, `<form>`, `<a>` — accessibility isn't an afterthought bolted on with ARIA — it's a structural property of the document itself. Screen readers navigate native HTML semantics: headings, paragraphs, links, and form controls — a complete, navigable information architecture, not a maze of layout primitives.
 
 The ALPS profile doubles as an accessibility specification: it defines what every element means, what actions are available, and how states connect.
 

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -21,11 +21,21 @@
 </head>
 <body class="markdown-body">
     <h1>ALPS Demos</h1>
+    <h2>State Diagrams</h2>
+    <p>Interactive state transition diagrams generated from ALPS profiles.</p>
     <ul>
         <li><a href="minimal/alps.html">minimal</a> - Simple blog API (S)</li>
         <li><a href="bookstore/alps.html">bookstore</a> - Online bookstore (M)</li>
         <li><a href="lms/alps.html">lms</a> - Learning management system (L)</li>
         <li><a href="amazon/alps.html">amazon</a> - E-commerce platform (XL)</li>
+    </ul>
+    <h2>ALPS Profiles</h2>
+    <p>Source ALPS profiles in XML and JSON formats. Use these as references for creating your own profiles.</p>
+    <ul>
+        <li><a href="minimal/alps.json">minimal/alps.json</a> - 29 lines, starter template</li>
+        <li><a href="bookstore/alps.xml">bookstore/alps.xml</a> - XML format, e-commerce flow with checkout</li>
+        <li><a href="lms/alps.xml">lms/alps.xml</a> - Multi-role system (student, instructor, admin)</li>
+        <li><a href="amazon/alps.json">amazon/alps.json</a> - Large-scale JSON format</li>
     </ul>
 </body>
 </html>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -44,9 +44,21 @@ Warnings (best practice): W001 (missing title), W002 (safe should start with go)
 
 ## Examples
 
-- [Minimal Blog API (JSON)](https://github.com/alps-asd/app-state-diagram/blob/2.x/docs/demo/minimal/alps.json): 29-line starter template
-- [Bookstore (XML)](https://github.com/alps-asd/app-state-diagram/blob/2.x/docs/demo/bookstore/alps.xml): XML format example
-- [Amazon (JSON)](https://github.com/alps-asd/app-state-diagram/blob/2.x/docs/demo/amazon/amazon.json): Large-scale profile
+### ALPS Profiles (by complexity)
+
+| Size | Example | Format | Description |
+|------|---------|--------|-------------|
+| S | [Minimal Blog API](https://github.com/alps-asd/app-state-diagram/blob/2.x/docs/demo/minimal/alps.json) | JSON | 29-line starter template with posts |
+| M | [Bookstore](https://github.com/alps-asd/app-state-diagram/blob/2.x/docs/demo/bookstore/alps.xml) | XML | E-commerce flow: catalog, cart, checkout, payment |
+| L | [LMS](https://github.com/alps-asd/app-state-diagram/blob/2.x/docs/demo/lms/alps.xml) | XML | Multi-role system (student, instructor, admin) |
+| XL | [Amazon](https://github.com/alps-asd/app-state-diagram/blob/2.x/docs/demo/amazon/alps.json) | JSON | Large-scale e-commerce with detailed pricing |
+
+### Live Demos (interactive state diagrams)
+
+- [Minimal](https://alps-asd.github.io/app-state-diagram/demo/minimal/alps.html)
+- [Bookstore](https://alps-asd.github.io/app-state-diagram/demo/bookstore/alps.html)
+- [LMS](https://alps-asd.github.io/app-state-diagram/demo/lms/alps.html)
+- [Amazon](https://alps-asd.github.io/app-state-diagram/demo/amazon/alps.html)
 
 ## Optional
 

--- a/docs/skills/mock/SKILL.md
+++ b/docs/skills/mock/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: alps2mock
+description: Generate multi-fidelity HTML mock from ALPS profile. Creates semantic HTML pages, three CSS fidelity levels, mock API responses, and i18n labels — all from a single ALPS profile.
+---
+
+# ALPS to Mock Generator
+
+Generate a complete HTML mock site from an ALPS profile. Every CSS class in the generated HTML is an ALPS descriptor ID — zero presentation classes. This enables CSS-only fidelity switching between bare HTML, wireframe, and production quality.
+
+## When to Use
+
+- User asks to generate a mock, prototype, or wireframe from an ALPS profile
+- User says "alps2mock", "generate mock", "create wireframe", "mock from alps"
+- User wants to visualize ALPS states as browsable HTML pages
+- User wants to review information architecture before visual design
+
+## What It Generates
+
+From a single ALPS profile, generate the following directory structure:
+
+```
+{output-dir}/
+├── profile/
+│   └── alps.xml              # Copy of source ALPS profile
+├── html/
+│   ├── index.html            # Home state
+│   ├── catalog.html          # One HTML per ALPS state
+│   └── ...
+├── css/
+│   ├── level1.css            # Bare readability
+│   ├── level2.css            # Wireframe (information skeleton)
+│   └── level3.css            # Production quality
+├── api/
+│   ├── home.json             # HAL+JSON mock response per state
+│   └── ...
+├── i18n/
+│   └── labels.json           # ALPS descriptor ID → human label mapping
+└── mock-switch               # Shell script to switch CSS fidelity
+```
+
+## Core Principle: Semantic First HTML
+
+**Every `class` attribute in the generated HTML MUST be an ALPS descriptor ID.** No presentation classes (`bg-white`, `rounded-lg`, `flex`, `text-sm`, etc.) are allowed in HTML.
+
+Three layers of ALPS become CSS classes:
+
+| Layer | Example classes | Source |
+|-------|----------------|--------|
+| Ontology | `.title`, `.author`, `.price` | Semantic descriptors |
+| Taxonomy | `.Book`, `.Catalog`, `.ShoppingCart` | State descriptors |
+| Choreography | `.goToBookDetails`, `.doAddToCart` | Transition descriptors |
+
+### HTML Generation Rules
+
+1. **One HTML file per ALPS state** (Taxonomy descriptor with nested descriptors)
+2. **`<link rel="profile" href="../profile/alps.xml">`** in every `<head>`
+3. **`<link rel="stylesheet" href="../css/level2.css">`** as default stylesheet
+4. **Semantic HTML elements**: `<article>` for entities, `<form>` for unsafe/idempotent transitions, `<a>` for safe transitions, `<nav>` for navigation groups
+5. **ALPS `title` attribute** maps to HTML `title` attribute on links and buttons
+6. **ALPS `doc` value** is NOT rendered in HTML — it's for developers, not end users
+7. **Placeholder content**: Use realistic sample data (not "Lorem ipsum")
+
+### Example: Book Detail Page
+
+Given this ALPS taxonomy:
+
+```xml
+<descriptor id="Book" title="Book">
+    <descriptor href="#id"/>
+    <descriptor href="#title"/>
+    <descriptor href="#author"/>
+    <descriptor href="#isbn"/>
+    <descriptor href="#price"/>
+    <descriptor href="#doAddToCart"/>
+    <descriptor href="#goToCatalog"/>
+</descriptor>
+```
+
+Generate:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Book - ALPS Book Store</title>
+  <link rel="profile" href="../profile/alps.xml">
+  <link rel="stylesheet" href="../css/level2.css">
+</head>
+<body>
+  <header>
+    <div>
+      <a href="index.html">ALPS Book Store</a>
+      <nav>
+        <a href="catalog.html" class="goToCatalog">Catalog</a>
+        <a href="shoppingcart.html" class="goToCart">Cart</a>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <article class="Book">
+      <span class="id" hidden>BK-001</span>
+      <h1 class="title">The Art of Programming</h1>
+      <p class="author">Jane Smith</p>
+      <dl>
+        <div><dt>ISBN</dt><dd class="isbn">978-4-1234-5678-9</dd></div>
+        <div><dt>Category</dt><dd class="category">Programming</dd></div>
+      </dl>
+      <p class="price">¥2,480</p>
+      <form method="post" action="shoppingcart.html" class="doAddToCart">
+        <input type="hidden" name="id" value="BK-001" class="id">
+        <label for="quantity">Qty</label>
+        <input type="number" id="quantity" name="quantity" min="1" value="1" class="quantity">
+        <button type="submit">Add to Cart</button>
+      </form>
+    </article>
+  </main>
+  <footer>
+    <div>Mock generated from ALPS profile: ALPS Book Store</div>
+  </footer>
+</body>
+</html>
+```
+
+Key points:
+- `class="Book"`, `class="title"`, `class="doAddToCart"` — all ALPS descriptor IDs
+- `<form>` for `doAddToCart` (unsafe transition) with nested descriptors as form fields
+- `<a>` for `goToCatalog` (safe transition)
+- Realistic sample data, not placeholder text
+
+## CSS Fidelity Levels
+
+### level1.css — Bare Readability
+
+Minimal styling for raw HTML readability. No layout, no branding. Think GitHub Pages rendering.
+
+```css
+body {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+}
+a { color: #0366d6; }
+```
+
+### level2.css — Wireframe (Information Skeleton)
+
+The wireframe level is the most important. It makes the ALPS vocabulary visible:
+
+```css
+/* ALPS ID tooltip on hover */
+[class]:hover::after {
+  content: "." attr(class);
+  position: absolute;
+  top: -1.25rem;
+  left: 0;
+  font-size: 0.5625rem;
+  font-family: 'SF Mono', Menlo, Consolas, monospace !important;
+  color: #fff;
+  background: #555;
+  padding: 0.125rem 0.375rem;
+  border-radius: 2px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+/* Block structure: dashed borders */
+section, article, aside {
+  border: 1px dashed #ddd;
+  padding: 1rem;
+}
+
+/* X-box image placeholder */
+img {
+  background: #eee;
+  background-image:
+    linear-gradient(to top right, transparent calc(50% - 1px), #ccc, transparent calc(50% + 1px)),
+    linear-gradient(to top left, transparent calc(50% - 1px), #ccc, transparent calc(50% + 1px));
+  min-height: 120px;
+  object-position: -9999px;
+}
+```
+
+Key features:
+- **Hover tooltips** show ALPS descriptor IDs (`.Book`, `.title`, `.goToBookDetails`)
+- **Dashed borders** visualize block boundaries
+- **X-box placeholders** for images
+- **No color branding** — structure only
+- **Grid layouts** use semantic selectors (`.Catalog > div`, not `.book-grid`)
+
+### level3.css — Production Quality
+
+Full design system with design tokens, custom typography, color palette, transitions, and responsive layout. CSS targets ALPS semantic classes:
+
+```css
+.Book .title {
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-weight: 500;
+}
+
+.doAddToCart {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+```
+
+Key requirements:
+- **Design tokens** in `:root` (colors, fonts, spacing)
+- **Google Fonts** import for display typography
+- **Responsive breakpoints** (`@media (max-width: 768px)`)
+- **Hover/focus states** with transitions
+- **All selectors reference ALPS classes** — no `.btn-primary`, `.card`, `.grid` etc.
+
+## Mock API (HAL+JSON)
+
+Generate one JSON file per ALPS state, following HAL format:
+
+```json
+{
+  "id": "BK-001",
+  "title": "The Art of Programming",
+  "author": "Jane Smith",
+  "isbn": "978-4-1234-5678-9",
+  "price": 2480,
+  "category": "Programming",
+  "_links": {
+    "self": {"href": "/api/book/BK-001"},
+    "goToCatalog": {"href": "/api/catalog", "method": "GET"},
+    "doAddToCart": {"href": "/api/cart/items", "method": "POST"}
+  }
+}
+```
+
+Rules:
+- Field names match ALPS semantic descriptor IDs
+- `_links` keys match ALPS transition descriptor IDs
+- Safe transitions use `"method": "GET"`
+- Unsafe transitions use `"method": "POST"`
+- Idempotent transitions use `"method": "PUT"` or `"method": "DELETE"`
+
+## i18n Labels
+
+Generate `labels.json` mapping ALPS descriptor IDs to human-readable labels:
+
+```json
+{
+  "id": "ID",
+  "title": "Title",
+  "author": "Author",
+  "price": "Price",
+  "Book": "Book",
+  "Catalog": "Book Catalog",
+  "goToCatalog": "Go to Catalog",
+  "doAddToCart": "Add to Cart"
+}
+```
+
+Source: Use ALPS `title` attribute. If no title, use the descriptor `id` as-is.
+
+## mock-switch Script
+
+Generate a shell script that switches CSS fidelity across all HTML files:
+
+```bash
+#!/bin/bash
+# mock-switch — Switch mock fidelity level
+# Usage: ./mock-switch <1|2|3> [mock-dir]
+
+level=$1
+dir=${2:-.}
+
+if [[ ! "$level" =~ ^[123]$ ]]; then
+  echo "Usage: ./mock-switch <1|2|3> [mock-dir]"
+  exit 1
+fi
+
+count=0
+for f in "$dir"/html/*.html; do
+  [ -f "$f" ] || continue
+  sed -i '' "s|level[0-9]\.css|level${level}.css|g" "$f"
+  count=$((count + 1))
+done
+
+echo "Switched ${count} files to level${level}.css"
+```
+
+## Workflow
+
+1. **Read the ALPS profile** — Parse XML or JSON
+2. **Identify states** — Taxonomy descriptors with nested children
+3. **Generate HTML** — One page per state, semantic classes only
+4. **Generate CSS** — Three fidelity levels
+5. **Generate API** — HAL+JSON per state
+6. **Generate i18n** — Labels from ALPS titles
+7. **Generate mock-switch** — Shell script
+8. **Report** — List generated files and suggest opening in browser
+
+## Tips
+
+- **Start with level2.css** (wireframe) for information architecture review
+- **Hover elements** in level2 to see ALPS descriptor IDs
+- **Switch to level3** only after the information structure is approved
+- **The HTML never changes** — all design iteration happens in CSS
+- **Share the wireframe** with stakeholders before investing in visual design
+
+## Related
+
+- [Semantic First Design](https://alps-asd.github.io/app-state-diagram/blog/semantic-first-design.html) — The design philosophy behind this approach
+- [ALPS Specification §2.3.1](http://alps.io/spec/alps/spec.html) — Descriptor ID to class mapping
+- [CSS Zen Garden](http://www.csszengarden.com/) — The original proof that same HTML can have radically different designs

--- a/docs/skills/mock/SKILL.md
+++ b/docs/skills/mock/SKILL.md
@@ -76,7 +76,7 @@ Given this ALPS taxonomy:
 </descriptor>
 ```
 
-Generate:
+Generate (partial example — only showing the Book state; other states like ShoppingCart and their descriptors like `goToCart`, `category`, `quantity` are defined elsewhere in the full profile):
 
 ```html
 <!DOCTYPE html>
@@ -93,8 +93,8 @@ Generate:
     <div>
       <a href="index.html">ALPS Book Store</a>
       <nav>
-        <a href="catalog.html" class="goToCatalog">Catalog</a>
-        <a href="shoppingcart.html" class="goToCart">Cart</a>
+        <a href="catalog.html" class="goToCatalog" title="Go to Catalog">Catalog</a>
+        <a href="shoppingcart.html" class="goToCart" title="Go to Cart">Cart</a>
       </nav>
     </div>
   </header>
@@ -112,7 +112,7 @@ Generate:
         <input type="hidden" name="id" value="BK-001" class="id">
         <label for="quantity">Qty</label>
         <input type="number" id="quantity" name="quantity" min="1" value="1" class="quantity">
-        <button type="submit">Add to Cart</button>
+        <button type="submit" title="Add to Cart">Add to Cart</button>
       </form>
     </article>
   </main>
@@ -151,6 +151,10 @@ a { color: #0366d6; }
 The wireframe level is the most important. It makes the ALPS vocabulary visible:
 
 ```css
+[class] {
+  position: relative;
+}
+
 /* ALPS ID tooltip on hover */
 [class]:hover::after {
   content: "." attr(class);
@@ -282,7 +286,8 @@ fi
 count=0
 for f in "$dir"/html/*.html; do
   [ -f "$f" ] || continue
-  sed -i '' "s|level[0-9]\.css|level${level}.css|g" "$f"
+  tmp=$(mktemp)
+  sed "s|level[0-9]\.css|level${level}.css|g" "$f" > "$tmp" && mv "$tmp" "$f"
   count=$((count + 1))
 done
 

--- a/packages/app-state-diagram/src/generator/dot-generator.test.ts
+++ b/packages/app-state-diagram/src/generator/dot-generator.test.ts
@@ -532,4 +532,22 @@ describe('DotGenerator', () => {
     expect(dot).not.toMatch(/TOOLTIP="[^"]*Subscribe & Save/);
   });
 
+  it('should use black edge color for single unsafe transition', () => {
+    const alps: AlpsDocument = {
+      alps: {
+        descriptor: [
+          {
+            id: 'Home',
+            descriptor: [{ href: '#doDelete' }]
+          },
+          { id: 'Deleted' },
+          { id: 'doDelete', type: 'unsafe', rt: '#Deleted' }
+        ]
+      }
+    };
+    const dot = generateDot(alps);
+    expect(dot).toContain('Home -> Deleted');
+    expect(dot).toContain('color="#000000"');
+  });
+
 });

--- a/packages/app-state-diagram/src/generator/dot-generator.ts
+++ b/packages/app-state-diagram/src/generator/dot-generator.ts
@@ -118,7 +118,7 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
         group.ids.push(trans.id);
         group.labels.push(transLabel);
         group.colors.push(color);
-        group.types.push(trans.type || '');
+        group.types.push(trans.type!);
         group.titles.push(trans.title || trans.id);
       }
     }


### PR DESCRIPTION
## Summary

- Add `alps2mock` skill (`docs/skills/mock/SKILL.md`) for generating multi-fidelity HTML mocks from ALPS profiles
  - Semantic HTML only (every `class` = ALPS descriptor ID, zero presentation classes)
  - Three CSS fidelity levels: bare HTML, wireframe (with ALPS ID tooltips), production quality
  - HAL+JSON mock API responses, i18n labels, mock-switch script
- Add Semantic First Design blog article (`docs/blog/semantic-first-design.md`)
- Update README, AI Integration Guide, demo index, and llms.txt to document the new skill and reorganize examples

## Test plan

- [ ] Verify `docs/skills/mock/SKILL.md` renders correctly on GitHub
- [ ] Verify `docs/blog/semantic-first-design.md` renders correctly
- [ ] Verify `docs/demo/index.html` links work on GitHub Pages
- [ ] Verify `docs/llms.txt` live demo links resolve
- [ ] Test skill installation: `curl -o .claude/skills/mock/SKILL.md` from raw URL after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Mock Generation guide describing HTML generation from ALPS profiles
  * Introduced Semantic First Design article covering content-presentation separation patterns
  * Expanded demo resources with State Diagrams section and structured ALPS profile listing
  * Published complete ALPS to Mock Generator documentation with output specifications

* **Tests**
  * Added validation for unsafe state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->