### PR TITLE
Add shareable URL state controls to editor

### DIFF
--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -408,6 +408,17 @@ function scrollToDescriptor(id) {
     }
 }
 
+function setDescriptorHash(id) {
+    if (!id) return;
+    if (window.updateDiagramHash) {
+        window.updateDiagramHash(id);
+        return;
+    }
+    const url = new URL(window.location.href);
+    url.hash = '#' + encodeURIComponent(id);
+    window.history.replaceState(null, '', url.toString());
+}
+
 // Listen for messages from parent (for Preview mode scroll)
 window.addEventListener('message', function(event) {
     if (event.data && event.data.type === 'scrollToDescriptor') {
@@ -439,6 +450,7 @@ function setupSvgEventHandlers() {
             if (href && href.startsWith('#')) {
                 const id = href.substring(1);
                 console.log('Extracted ID:', id);
+                setDescriptorHash(id);
 
                 if (window.parent !== window) {
                     // In iframe (editor mode): Send message to parent window
@@ -470,8 +482,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 href = href.substring(1);
             }
             const id = href.substring(1);
+            const currentRow = this.closest('tr');
+            const targetRow = document.getElementById('descriptor-' + id);
+            const hasDescriptorTarget = Boolean(targetRow);
+            if (hasDescriptorTarget) setDescriptorHash(id);
 
-            if (window.parent !== window) {
+            if (window.parent !== window && hasDescriptorTarget) {
                 // In iframe (editor mode): Send message to parent to jump to editor line
                 window.parent.postMessage({
                     type: 'jumpToId',
@@ -491,8 +507,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
 
             // Check if this is a link to a different row (rt/Contained) or self (ID column)
-            const currentRow = this.closest('tr');
-            const targetRow = document.getElementById('descriptor-' + id);
 
             // Only scroll and highlight if linking to a different row
             if (targetRow && targetRow !== currentRow) {
@@ -654,12 +668,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 e.stopPropagation();
                 const id = href.substring(1);
                 console.log('Document click - extracted ID:', id);
+                if (!document.getElementById('descriptor-' + id)) return;
+                setDescriptorHash(id);
                 
                 if (window.parent !== window) {
                     window.parent.postMessage({
                         type: 'jumpToId',
                         id: id
                     }, '*');
+                } else {
+                    scrollToDescriptor(id);
                 }
             }
         }
@@ -699,6 +717,96 @@ ${linksHtml}
 
 // Tag filtering - using same logic as production ASD
 const tagDescriptorMap = ${escapeJsonForScript(tagDescriptorMap)};
+let isApplyingUrlState = false;
+let hasExplicitSizeMode = false;
+let currentDescriptorHash = '';
+
+const normalizeSizeMode = (size) => {
+    if (size === 'compact') return 'half';
+    return ['original', 'fit', 'half'].includes(size) ? size : '';
+};
+
+const getTagsFromValues = (values) => {
+    return values
+        .flatMap(value => String(value).split(','))
+        .map(tag => tag.trim())
+        .filter(tag => tag && Object.prototype.hasOwnProperty.call(tagDescriptorMap, tag));
+};
+
+const getCurrentHash = () => {
+    return window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : '';
+};
+
+const getCurrentLabelMode = () => {
+    return document.querySelector('input[name="labelMode"]:checked')?.value || 'id';
+};
+
+const getCurrentSizeMode = () => {
+    return document.querySelector('input[name="sizeMode"]:checked')?.value || 'original';
+};
+
+const getSelectedTags = () => {
+    return Array.from(document.querySelectorAll('.tag-trigger-checkbox'))
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.getAttribute('data-tag'))
+        .filter(Boolean);
+};
+
+const readUrlState = () => {
+    const params = new URLSearchParams(window.location.search);
+    return {
+        tag: getTagsFromValues(params.getAll('tag')),
+        label: params.get('label') === 'title' ? 'title' : 'id',
+        size: normalizeSizeMode(params.get('size')),
+        hash: getCurrentHash()
+    };
+};
+
+const collectUrlState = () => {
+    return {
+        tag: getSelectedTags(),
+        label: getCurrentLabelMode(),
+        size: getCurrentSizeMode(),
+        hash: currentDescriptorHash || getCurrentHash()
+    };
+};
+
+const replaceUrlState = (state) => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('tag');
+    if (state.tag.length > 0) {
+        url.searchParams.set('tag', state.tag.join(','));
+    }
+    if (state.label === 'title') {
+        url.searchParams.set('label', 'title');
+    } else {
+        url.searchParams.delete('label');
+    }
+    const size = normalizeSizeMode(state.size);
+    if (size) {
+        url.searchParams.set('size', size);
+    } else {
+        url.searchParams.delete('size');
+    }
+    url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+    window.history.replaceState(null, '', url.toString());
+};
+
+const publishUrlState = () => {
+    if (isApplyingUrlState) return;
+    hasExplicitSizeMode = true;
+    const state = collectUrlState();
+    if (window.parent !== window) {
+        window.parent.postMessage({ type: 'diagramStateChanged', state }, '*');
+    } else {
+        replaceUrlState(state);
+    }
+};
+
+window.updateDiagramHash = (id) => {
+    currentDescriptorHash = id || '';
+    publishUrlState();
+};
 
 // Changes color of SVG elements by title (matching production ASD)
 const changeColorByTitle = (titleOrClass, newNodeColor, newEdgeColor, highlight = false) => {
@@ -744,13 +852,21 @@ const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', function() {
-            const tag = this.getAttribute('data-tag');
-            this.checked ?
-                document.dispatchEvent(new CustomEvent('tagon-' + tag)) :
-                document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+            applySelectedTagsToDiagram();
+            publishUrlState();
         });
     });
 };
+
+function applySelectedTagsToDiagram() {
+    const selectedTags = new Set(getSelectedTags());
+    Object.keys(tagDescriptorMap).forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+    });
+    selectedTags.forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagon-' + tag));
+    });
+}
 
 // Tag colors (cycle through for multiple tags)
 const tagColors = ['LightGreen', 'SkyBlue', 'LightCoral', 'LightSalmon', 'Khaki', 'Plum', 'Wheat'];
@@ -929,6 +1045,15 @@ async function regenerateSvg(labelMode) {
         console.log('SVG regenerated with labelMode:', labelMode);
         // Re-attach SVG event handlers after regeneration
         setupSvgEventHandlers();
+        applySelectedTagsToDiagram();
+        if (hasExplicitSizeMode) {
+            applySizeMode(getCurrentSizeMode());
+        } else {
+            autoSelectSizeMode();
+        }
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
     } catch (error) {
         console.error('Error regenerating SVG:', error);
         svgGraph.innerHTML = '<p style="color:red;">Error regenerating diagram: ' + error.message + '</p>';
@@ -937,39 +1062,52 @@ async function regenerateSvg(labelMode) {
 
 document.querySelectorAll('input[name="labelMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        regenerateSvg(this.value);
+        regenerateSvg(this.value).then(() => publishUrlState());
     });
 });
 
 // Size mode toggle - keep selector position stable
 document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        const selector = this.closest('.selector-container');
-        const selectorRect = selector.getBoundingClientRect();
-        const selectorTopBefore = selectorRect.top;
-
-        const svgContainer = document.getElementById('svg-container');
-        svgContainer.classList.remove('fit-width', 'half-size');
-        if (this.value === 'fit') {
-            svgContainer.classList.add('fit-width');
-        } else if (this.value === 'half') {
-            svgContainer.classList.add('half-size');
-        }
-
-        // Adjust scroll to keep selector at same screen position (instant, no animation)
-        requestAnimationFrame(() => {
-            const selectorTopAfter = selector.getBoundingClientRect().top;
-            const scrollDiff = selectorTopAfter - selectorTopBefore;
-            window.scrollTo({ top: window.scrollY + scrollDiff, behavior: 'instant' });
-            if (this.value === 'original' || this.value === 'half') {
-                centerSvgScroll();
-            }
-        });
+        applySizeMode(this.value, true);
+        publishUrlState();
     });
 });
 
+function applySizeMode(sizeMode, explicit = false) {
+    const normalizedSize = normalizeSizeMode(sizeMode);
+    const svgContainer = document.getElementById('svg-container');
+    if (!svgContainer || !normalizedSize) return;
+    hasExplicitSizeMode = hasExplicitSizeMode || explicit;
+
+    const radio = document.querySelector('input[name="sizeMode"][value="' + normalizedSize + '"]');
+    if (radio) radio.checked = true;
+
+    const selector = document.querySelector('.selector-container');
+    const selectorTopBefore = selector ? selector.getBoundingClientRect().top : 0;
+
+    svgContainer.classList.remove('fit-width', 'half-size');
+    if (normalizedSize === 'fit') {
+        svgContainer.classList.add('fit-width');
+    } else if (normalizedSize === 'half') {
+        svgContainer.classList.add('half-size');
+    }
+
+    requestAnimationFrame(() => {
+        if (selector) {
+            const selectorTopAfter = selector.getBoundingClientRect().top;
+            const scrollDiff = selectorTopAfter - selectorTopBefore;
+            window.scrollTo({ top: window.scrollY + scrollDiff, behavior: 'instant' });
+        }
+        if (normalizedSize === 'original' || normalizedSize === 'half') {
+            centerSvgScroll();
+        }
+    });
+}
+
 // Auto-select size mode based on SVG width vs container width
 function autoSelectSizeMode() {
+    if (hasExplicitSizeMode) return;
     const svgContainer = document.getElementById('svg-container');
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
@@ -983,6 +1121,7 @@ function autoSelectSizeMode() {
 
     // Use setTimeout to allow reflow before measuring
     setTimeout(() => {
+        if (hasExplicitSizeMode) return;
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
 
@@ -1002,6 +1141,49 @@ function autoSelectSizeMode() {
     }, 0);
 }
 
+async function applyUrlState(state) {
+    isApplyingUrlState = true;
+    try {
+        const nextState = state || readUrlState();
+        const selectedTags = Array.isArray(nextState.tag) ? nextState.tag : [];
+        currentDescriptorHash = nextState.hash || '';
+
+        document.querySelectorAll('.tag-trigger-checkbox').forEach(checkbox => {
+            const tag = checkbox.getAttribute('data-tag');
+            checkbox.checked = Boolean(tag && selectedTags.includes(tag));
+        });
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        }
+
+        const currentLabelMode = getCurrentLabelMode();
+        const labelRadio = document.querySelector('input[name="labelMode"][value="' + nextState.label + '"]');
+        if (labelRadio) labelRadio.checked = true;
+        if (currentLabelMode !== nextState.label) {
+            await regenerateSvg(nextState.label);
+        }
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        } else {
+            autoSelectSizeMode();
+        }
+        applySelectedTagsToDiagram();
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
+    } finally {
+        isApplyingUrlState = false;
+    }
+}
+
+window.addEventListener('message', function(event) {
+    if (event.data && event.data.type === 'applyUrlState') {
+        applyUrlState(event.data.state);
+    }
+});
+
 // Center horizontal scroll position (for Original mode)
 function centerSvgScroll() {
     const svgContainer = document.getElementById('svg-container');
@@ -1014,6 +1196,7 @@ function centerSvgScroll() {
 }
 
 // Run once when DOM is ready and on window resize
+applyUrlState();
 document.addEventListener('DOMContentLoaded', autoSelectSizeMode);
 window.addEventListener('resize', autoSelectSizeMode);
 </script>

--- a/docs/js/scripts.js
+++ b/docs/js/scripts.js
@@ -14,6 +14,7 @@ class AlpsEditor {
         // Portable static detection: prefer explicit flag; default to static when flag is absent
         const hasApi = (typeof window.ALPSEDITOR_HAS_API === 'boolean') ? window.ALPSEDITOR_HAS_API : false;
         this.isStaticMode = !hasApi || this.isLocalMode;
+        this.initialUrlState = this.readSharedUrlState();
         // Ensure static/local environments use client-side diagramming before first preview
         if (this.isLocalMode || this.isStaticMode) {
             this.adapterManager.setAdapter('alps2dot');
@@ -325,11 +326,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             const previousMode = this.previousViewMode || 'document';
             selector.value = previousMode;
             this.applyViewMode(previousMode);
+            this.replaceSharedUrlState({ view: previousMode });
         } else {
             // Save current mode and switch to preview
             this.previousViewMode = selector.value;
             selector.value = 'preview';
             this.applyViewMode('preview');
+            this.replaceSharedUrlState({ view: 'preview' });
         }
     }
 
@@ -430,12 +433,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             const url = await this.adapterManager.generateDiagram(content, fileType);
 
             const iframe = document.getElementById('preview-frame');
-            iframe.src = url;
             // Apply view mode after iframe loads
             iframe.onload = () => {
                 const mode = document.getElementById('viewMode')?.value || 'document';
                 this.applyViewMode(mode);
+                this.applyDiagramUrlStateToFrame();
             };
+            iframe.src = url;
             this.debugLog('Preview updated');
             this.updateValidationMark(true);
             this.displayErrors([]);
@@ -453,6 +457,87 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         }
     }
 
+    getDefaultViewMode() {
+        return window.ALPS_INITIAL_CONTENT ? 'preview' : 'document';
+    }
+
+    getTagsFromValues(values) {
+        return values
+            .flatMap(value => String(value).split(','))
+            .map(tag => tag.trim())
+            .filter(Boolean);
+    }
+
+    normalizeSizeMode(size) {
+        if (size === 'compact') return 'half';
+        return ['original', 'fit', 'half'].includes(size) ? size : '';
+    }
+
+    readSharedUrlState() {
+        const params = new URLSearchParams(window.location.search);
+        const rawView = params.get('view');
+        const rawLabel = params.get('label');
+        return {
+            view: ['document', 'diagram', 'preview'].includes(rawView) ? rawView : this.getDefaultViewMode(),
+            tag: this.getTagsFromValues(params.getAll('tag')),
+            label: rawLabel === 'title' ? 'title' : 'id',
+            size: this.normalizeSizeMode(params.get('size')),
+            hash: window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : ''
+        };
+    }
+
+    replaceSharedUrlState(nextState) {
+        const currentState = this.readSharedUrlState();
+        const state = { ...currentState, ...nextState };
+        const url = new URL(window.location.href);
+
+        if (state.view && state.view !== this.getDefaultViewMode()) {
+            url.searchParams.set('view', state.view);
+        } else {
+            url.searchParams.delete('view');
+        }
+
+        url.searchParams.delete('tag');
+        if (Array.isArray(state.tag) && state.tag.length > 0) {
+            url.searchParams.set('tag', state.tag.join(','));
+        }
+
+        if (state.label === 'title') {
+            url.searchParams.set('label', 'title');
+        } else {
+            url.searchParams.delete('label');
+        }
+
+        const size = this.normalizeSizeMode(state.size);
+        if (size) {
+            url.searchParams.set('size', size);
+        } else {
+            url.searchParams.delete('size');
+        }
+
+        url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+        window.history.replaceState(null, '', url.toString());
+    }
+
+    getDiagramUrlState() {
+        const state = this.readSharedUrlState();
+        return {
+            tag: state.tag,
+            label: state.label,
+            size: state.size,
+            hash: state.hash
+        };
+    }
+
+    applyDiagramUrlStateToFrame() {
+        const iframe = document.getElementById('preview-frame');
+        if (!iframe?.contentWindow) return;
+        iframe.contentWindow.postMessage({
+            type: 'applyUrlState',
+            state: this.getDiagramUrlState()
+        }, '*');
+    }
+
     setupAdapterSelector() {
         // Always use alps2dot adapter
         this.adapterManager.setAdapter('alps2dot');
@@ -462,14 +547,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         const selector = document.getElementById('viewMode');
         if (!selector) return;
 
-        // Use preview mode for asd-generated HTML, document mode for online editor
-        const defaultMode = window.ALPS_INITIAL_CONTENT ? 'preview' : 'document';
-        selector.value = defaultMode;
-        this.applyViewMode(defaultMode);
+        selector.value = this.initialUrlState.view;
+        this.applyViewMode(selector.value);
 
         selector.addEventListener('change', (event) => {
             const mode = event.target.value;
             this.applyViewMode(mode);
+            this.replaceSharedUrlState({ view: mode });
         });
     }
 
@@ -1052,9 +1136,14 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             const isLocalOrBlob = this.isLocalMode || event.origin === 'null';
             if (!isLocalOrBlob && event.origin !== window.location.origin) return;
 
+            if (event.data && event.data.type === 'diagramStateChanged') {
+                this.replaceSharedUrlState(event.data.state || {});
+            }
+
             if (event.data && event.data.type === 'jumpToId') {
                 const id = event.data.id;
                 console.log('Jumping to ID:', id);
+                this.replaceSharedUrlState({ hash: id });
 
                 // In Preview mode, scroll to table row instead of editor
                 const viewMode = document.getElementById('viewMode')?.value;

--- a/packages/app-state-diagram/src/generator/html-generator.ts
+++ b/packages/app-state-diagram/src/generator/html-generator.ts
@@ -176,7 +176,18 @@ function scrollToDescriptor(id) {
     }
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+function setDescriptorHash(id) {
+    if (!id) return;
+    if (window.updateDiagramHash) {
+        window.updateDiagramHash(id);
+        return;
+    }
+    const url = new URL(window.location.href);
+    url.hash = '#' + encodeURIComponent(id);
+    window.history.replaceState(null, '', url.toString());
+}
+
+function setupSvgEventHandlers() {
     // Add click handlers to all SVG elements with href="#something"
     const svgLinks = document.querySelectorAll('svg a[href^="#"], svg a[*|href^="#"]');
 
@@ -188,10 +199,15 @@ document.addEventListener('DOMContentLoaded', function() {
             const href = this.getAttribute('href') || this.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
             if (href && href.startsWith('#')) {
                 const id = href.substring(1);
+                setDescriptorHash(id);
                 scrollToDescriptor(id);
             }
         });
     });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    setupSvgEventHandlers();
 
     // Handle table internal links
     document.querySelectorAll('table a[href^="#"]').forEach(link => {
@@ -214,6 +230,7 @@ document.addEventListener('DOMContentLoaded', function() {
             // Scroll to target row if different
             const currentRow = this.closest('tr');
             const targetRow = document.getElementById('descriptor-' + id);
+            if (targetRow) setDescriptorHash(id);
 
             if (targetRow && targetRow !== currentRow) {
                 targetRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -301,6 +318,96 @@ ${linksHtml}
 <script>
 // Tag filtering
 const tagDescriptorMap = ${escapeJsonForScript(tagDescriptorMap)};
+let isApplyingUrlState = false;
+let hasExplicitSizeMode = false;
+let currentDescriptorHash = '';
+
+const normalizeSizeMode = (size) => {
+    if (size === 'compact') return 'half';
+    return ['original', 'fit', 'half'].includes(size) ? size : '';
+};
+
+const getTagsFromValues = (values) => {
+    return values
+        .flatMap(value => String(value).split(','))
+        .map(tag => tag.trim())
+        .filter(tag => tag && Object.prototype.hasOwnProperty.call(tagDescriptorMap, tag));
+};
+
+const getCurrentHash = () => {
+    return window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : '';
+};
+
+const getCurrentLabelMode = () => {
+    return document.querySelector('input[name="labelMode"]:checked')?.value || 'id';
+};
+
+const getCurrentSizeMode = () => {
+    return document.querySelector('input[name="sizeMode"]:checked')?.value || 'original';
+};
+
+const getSelectedTags = () => {
+    return Array.from(document.querySelectorAll('.tag-trigger-checkbox'))
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.getAttribute('data-tag'))
+        .filter(Boolean);
+};
+
+const readUrlState = () => {
+    const params = new URLSearchParams(window.location.search);
+    return {
+        tag: getTagsFromValues(params.getAll('tag')),
+        label: params.get('label') === 'title' ? 'title' : 'id',
+        size: normalizeSizeMode(params.get('size')),
+        hash: getCurrentHash()
+    };
+};
+
+const collectUrlState = () => {
+    return {
+        tag: getSelectedTags(),
+        label: getCurrentLabelMode(),
+        size: getCurrentSizeMode(),
+        hash: currentDescriptorHash || getCurrentHash()
+    };
+};
+
+const replaceUrlState = (state) => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('tag');
+    if (state.tag.length > 0) {
+        url.searchParams.set('tag', state.tag.join(','));
+    }
+    if (state.label === 'title') {
+        url.searchParams.set('label', 'title');
+    } else {
+        url.searchParams.delete('label');
+    }
+    const size = normalizeSizeMode(state.size);
+    if (size) {
+        url.searchParams.set('size', size);
+    } else {
+        url.searchParams.delete('size');
+    }
+    url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+    window.history.replaceState(null, '', url.toString());
+};
+
+const publishUrlState = () => {
+    if (isApplyingUrlState) return;
+    hasExplicitSizeMode = true;
+    const state = collectUrlState();
+    if (window.parent !== window) {
+        window.parent.postMessage({ type: 'diagramStateChanged', state }, '*');
+    } else {
+        replaceUrlState(state);
+    }
+};
+
+window.updateDiagramHash = (id) => {
+    currentDescriptorHash = id || '';
+    publishUrlState();
+};
 
 const changeColorByTitle = (titleOrClass, newNodeColor, newEdgeColor, highlight = false) => {
     const elements = Array.from(document.getElementsByTagName('g'));
@@ -341,13 +448,21 @@ const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', function() {
-            const tag = this.getAttribute('data-tag');
-            this.checked ?
-                document.dispatchEvent(new CustomEvent('tagon-' + tag)) :
-                document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+            applySelectedTagsToDiagram();
+            publishUrlState();
         });
     });
 };
+
+function applySelectedTagsToDiagram() {
+    const selectedTags = new Set(getSelectedTags());
+    Object.keys(tagDescriptorMap).forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+    });
+    selectedTags.forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagon-' + tag));
+    });
+}
 
 const tagColors = ['LightGreen', 'SkyBlue', 'LightCoral', 'LightSalmon', 'Khaki', 'Plum', 'Wheat'];
 let colorIndex = 0;
@@ -493,6 +608,16 @@ async function regenerateSvg(labelMode) {
         const vizInstance = await Viz.instance();
         const svgString = vizInstance.renderString(dotContent, { format: 'svg' });
         svgGraph.innerHTML = svgString;
+        setupSvgEventHandlers();
+        applySelectedTagsToDiagram();
+        if (hasExplicitSizeMode) {
+            applySizeMode(getCurrentSizeMode());
+        } else {
+            autoSelectSizeMode();
+        }
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
     } catch (error) {
         console.error('Error regenerating SVG:', error);
         svgGraph.innerHTML = '<p style="color:red;">Error regenerating diagram: ' + error.message + '</p>';
@@ -501,38 +626,51 @@ async function regenerateSvg(labelMode) {
 
 document.querySelectorAll('input[name="labelMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        regenerateSvg(this.value);
+        regenerateSvg(this.value).then(() => publishUrlState());
     });
 });
 
 // Size mode toggle - keep selector position stable
 document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        const selector = this.closest('.selector-container');
-        const selectorRect = selector.getBoundingClientRect();
-        const selectorTopBefore = selectorRect.top;
-
-        const svgContainer = document.getElementById('svg-container');
-        svgContainer.classList.remove('fit-width', 'half-size');
-        if (this.value === 'fit') {
-            svgContainer.classList.add('fit-width');
-        } else if (this.value === 'half') {
-            svgContainer.classList.add('half-size');
-        }
-
-        // Adjust scroll to keep selector at same screen position (instant, no animation)
-        requestAnimationFrame(() => {
-            const selectorTopAfter = selector.getBoundingClientRect().top;
-            const scrollDiff = selectorTopAfter - selectorTopBefore;
-            window.scrollTo({ top: window.scrollY + scrollDiff, behavior: 'instant' });
-            if (this.value === 'original' || this.value === 'half') {
-                centerSvgScroll();
-            }
-        });
+        applySizeMode(this.value, true);
+        publishUrlState();
     });
 });
 
+function applySizeMode(sizeMode, explicit = false) {
+    const normalizedSize = normalizeSizeMode(sizeMode);
+    const svgContainer = document.getElementById('svg-container');
+    if (!svgContainer || !normalizedSize) return;
+    hasExplicitSizeMode = hasExplicitSizeMode || explicit;
+
+    const radio = document.querySelector('input[name="sizeMode"][value="' + normalizedSize + '"]');
+    if (radio) radio.checked = true;
+
+    const selector = document.querySelector('.selector-container');
+    const selectorTopBefore = selector ? selector.getBoundingClientRect().top : 0;
+
+    svgContainer.classList.remove('fit-width', 'half-size');
+    if (normalizedSize === 'fit') {
+        svgContainer.classList.add('fit-width');
+    } else if (normalizedSize === 'half') {
+        svgContainer.classList.add('half-size');
+    }
+
+    requestAnimationFrame(() => {
+        if (selector) {
+            const selectorTopAfter = selector.getBoundingClientRect().top;
+            const scrollDiff = selectorTopAfter - selectorTopBefore;
+            window.scrollTo({ top: window.scrollY + scrollDiff, behavior: 'instant' });
+        }
+        if (normalizedSize === 'original' || normalizedSize === 'half') {
+            centerSvgScroll();
+        }
+    });
+}
+
 function autoSelectSizeMode() {
+    if (hasExplicitSizeMode) return;
     const svgContainer = document.getElementById('svg-container');
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
@@ -544,6 +682,7 @@ function autoSelectSizeMode() {
     svgContainer.classList.remove('fit-width', 'half-size');
 
     setTimeout(() => {
+        if (hasExplicitSizeMode) return;
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
 
@@ -562,6 +701,49 @@ function autoSelectSizeMode() {
     }, 0);
 }
 
+async function applyUrlState(state) {
+    isApplyingUrlState = true;
+    try {
+        const nextState = state || readUrlState();
+        const selectedTags = Array.isArray(nextState.tag) ? nextState.tag : [];
+        currentDescriptorHash = nextState.hash || '';
+
+        document.querySelectorAll('.tag-trigger-checkbox').forEach(checkbox => {
+            const tag = checkbox.getAttribute('data-tag');
+            checkbox.checked = Boolean(tag && selectedTags.includes(tag));
+        });
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        }
+
+        const currentLabelMode = getCurrentLabelMode();
+        const labelRadio = document.querySelector('input[name="labelMode"][value="' + nextState.label + '"]');
+        if (labelRadio) labelRadio.checked = true;
+        if (currentLabelMode !== nextState.label) {
+            await regenerateSvg(nextState.label);
+        }
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        } else {
+            autoSelectSizeMode();
+        }
+        applySelectedTagsToDiagram();
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
+    } finally {
+        isApplyingUrlState = false;
+    }
+}
+
+window.addEventListener('message', function(event) {
+    if (event.data && event.data.type === 'applyUrlState') {
+        applyUrlState(event.data.state);
+    }
+});
+
 function centerSvgScroll() {
     const svgContainer = document.getElementById('svg-container');
     if (svgContainer && !svgContainer.classList.contains('fit-width')) {
@@ -572,6 +754,7 @@ function centerSvgScroll() {
     }
 }
 
+applyUrlState();
 document.addEventListener('DOMContentLoaded', autoSelectSizeMode);
 window.addEventListener('resize', autoSelectSizeMode);
 
@@ -611,12 +794,15 @@ window.loadText = async function(text) {
         const labelMode = document.querySelector('input[name="labelMode"]:checked')?.value || 'id';
         await regenerateSvg(labelMode);
 
-        // Set Fit to Width
-        const svgContainer = document.getElementById('svg-container');
-        const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
-        if (svgContainer && fitRadio) {
-            svgContainer.classList.add('fit-width');
-            fitRadio.checked = true;
+        if (hasExplicitSizeMode) {
+            applySizeMode(getCurrentSizeMode());
+        } else {
+            const svgContainer = document.getElementById('svg-container');
+            const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
+            if (svgContainer && fitRadio) {
+                svgContainer.classList.add('fit-width');
+                fitRadio.checked = true;
+            }
         }
 
         console.log('ALPS reloaded via loadText');


### PR DESCRIPTION
## Summary

- Add shareable URL state for generated standalone HTML and the official editor preview.
- Restore and update `tag`, `label`, `size`, and descriptor fragments in generated diagrams.
- Restore and update editor `view=document|diagram|preview` on the parent URL, with iframe state synced through `postMessage`.
- Support the existing 2.x Compact size option as `size=half` in addition to `size=original` and `size=fit`.

## Validation

- `git diff --check`
- `node --check docs/js/diagramAdapters.js`
- `node --check docs/js/scripts.js`
- `pnpm -r build`
- `pnpm -r test`
- Headless Chrome verification for official editor:
  - `index.html?view=preview&tag=flow-purchase&label=title&size=half#Cart`
  - Restored preview mode, title labels, compact size, checked tag, descriptor target, and SVG.
  - Toggling the tag updated the parent URL in realtime.
- Headless Chrome verification for generated standalone HTML:
  - `asd-official-standalone.html?tag=cart,catalog&label=title&size=fit#ShoppingCart`
  - Restored checked tags, title labels, fit size, descriptor target, and SVG.
  - Toggling a tag updated the URL in realtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagram state (selected tags, label mode, size mode, and descriptor selection) is now preserved and shareable via URLs
  * Improved editor and diagram preview synchronization through message-based state updates
  * Enhanced cross-frame communication for better state consistency between editor and diagram views
  * URL-based state persistence allows users to share and restore diagram configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->