### PR TITLE
Add selected tag-only diagram filtering

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,6 @@
     </div>
 </div>
 <div id="debug"></div>
-<script type="module" src="js/scripts.js"></script>
+<script type="module" src="js/scripts.js?v=tag-filter-20260606b"></script>
 </body>
 </html>

--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -878,8 +878,13 @@ const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', async function() {
+            const wasTagOnlyMode = isTagOnlyMode();
             updateTagOnlyControl();
-            await regenerateSvg(getCurrentLabelMode());
+            if (wasTagOnlyMode || isTagOnlyMode()) {
+                await regenerateSvg(getCurrentLabelMode());
+            } else {
+                applySelectedTagsToDiagram();
+            }
             publishUrlState();
         });
     });

--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -314,11 +314,12 @@ a{cursor:pointer;}
 #svg-container{display:flex;overflow-x:scroll;margin:20px 0;}
 #svg-graph{flex-shrink:0;text-align:center;}
 #svg-graph svg{display:block;max-width:none;}
-#svg-container.fit-width #svg-graph svg{max-width:100% !important;width:100% !important;height:auto !important;}
+#svg-container.fit-width #svg-graph svg{max-width:100% !important;height:auto !important;}
 #svg-container.fit-width #svg-graph{flex-shrink:1;width:100%;}
 #svg-container.half-size #svg-graph svg{max-width:60% !important;width:60% !important;height:auto !important;}
 #svg-container.half-size #svg-graph{flex-shrink:0;}
 h1,h2{margin-top:0;}
+.empty-diagram-message{color:#666;text-align:center;margin:30px 0;}
 /* Legend */
 .legend{display:flex;gap:20px;margin:20px 0;flex-wrap:wrap;}
 table .legend{background-color:transparent;padding:0;margin:0;display:inline-flex;align-items:center;}
@@ -375,6 +376,8 @@ td a:hover{text-decoration:underline;}
 .selector-option{margin-right:15px;display:inline-block;cursor:pointer;}
 .selector-option label{cursor:pointer;}
 .tag-trigger-checkbox{margin-right:3px;}
+.tag-only-option{border-left:1px solid #d0d7de;padding-left:12px;margin-left:4px;}
+.tag-only-checkbox{margin-right:3px;}
 /* Override tag selector styles when inside selector-row */
 .selector-row .selector-container{margin:0;padding:0;background:none;border-radius:0;display:inline;}
 /* Meta container for def, rt, tag */
@@ -707,7 +710,9 @@ document.addEventListener('DOMContentLoaded', function() {
         <span class="selector-option"><input type="radio" name="sizeMode" value="half"><label> Compact</label></span>
         <span class="selector-option"><input type="radio" name="sizeMode" value="fit"><label> Fit to width</label></span>
     </div>
-${tagSelectorHtml ? `    <div class="selector-row">${tagSelectorHtml}</div>` : ''}
+${tagSelectorHtml ? `    <div class="selector-row">${tagSelectorHtml}
+        <span class="selector-option tag-only-option"><input type="checkbox" id="tag-only-mode" class="tag-only-checkbox" disabled><label for="tag-only-mode"> Show selected tags only</label></span>
+    </div>` : ''}
 </div>
 ${tableHtml}
 ${linksHtml}
@@ -756,6 +761,7 @@ const readUrlState = () => {
     const params = new URLSearchParams(window.location.search);
     return {
         tag: getTagsFromValues(params.getAll('tag')),
+        tagOnly: params.get('tagOnly') === '1',
         label: params.get('label') === 'title' ? 'title' : 'id',
         size: normalizeSizeMode(params.get('size')),
         hash: getCurrentHash()
@@ -765,6 +771,7 @@ const readUrlState = () => {
 const collectUrlState = () => {
     return {
         tag: getSelectedTags(),
+        tagOnly: isTagOnlyMode(),
         label: getCurrentLabelMode(),
         size: getCurrentSizeMode(),
         hash: currentDescriptorHash || getCurrentHash()
@@ -776,6 +783,11 @@ const replaceUrlState = (state) => {
     url.searchParams.delete('tag');
     if (state.tag.length > 0) {
         url.searchParams.set('tag', state.tag.join(','));
+    }
+    if (state.tagOnly) {
+        url.searchParams.set('tagOnly', '1');
+    } else {
+        url.searchParams.delete('tagOnly');
     }
     if (state.label === 'title') {
         url.searchParams.set('label', 'title');
@@ -794,7 +806,6 @@ const replaceUrlState = (state) => {
 
 const publishUrlState = () => {
     if (isApplyingUrlState) return;
-    hasExplicitSizeMode = true;
     const state = collectUrlState();
     if (window.parent !== window) {
         window.parent.postMessage({ type: 'diagramStateChanged', state }, '*');
@@ -847,12 +858,28 @@ const setupTagEventListener = (eventName, ids, color, defaultColor = 'lightgrey'
     document.addEventListener('tagoff-' + eventName, () => changeColor(true));
 };
 
+const isTagOnlyMode = () => {
+    const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+    return Boolean(tagOnlyCheckbox && tagOnlyCheckbox.checked && getSelectedTags().length > 0);
+};
+
+const updateTagOnlyControl = () => {
+    const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+    if (!tagOnlyCheckbox) return;
+    const hasSelectedTags = getSelectedTags().length > 0;
+    tagOnlyCheckbox.disabled = !hasSelectedTags;
+    if (!hasSelectedTags) {
+        tagOnlyCheckbox.checked = false;
+    }
+};
+
 // Sets up triggers for tag checkboxes
 const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
-        checkbox.addEventListener('change', function() {
-            applySelectedTagsToDiagram();
+        checkbox.addEventListener('change', async function() {
+            updateTagOnlyControl();
+            await regenerateSvg(getCurrentLabelMode());
             publishUrlState();
         });
     });
@@ -879,9 +906,20 @@ Object.keys(tagDescriptorMap).forEach(tag => {
 });
 
 setupTagTrigger();
+updateTagOnlyControl();
 
 // Label mode switching
 const alpsData = ${escapeJsonForScript(alpsData)};
+
+function getSelectedDescriptorIds() {
+    const ids = new Set();
+    getSelectedTags().forEach(tag => {
+        (tagDescriptorMap[tag] || []).forEach(id => {
+            if (id) ids.add(id);
+        });
+    });
+    return ids;
+}
 
 // NOTE: The escape functions below use double-escaped patterns (e.g., /\\\\\\\\/g instead of /\\\\/g)
 // because this code is embedded in a JavaScript template literal within the HTML generator.
@@ -914,7 +952,7 @@ function escapeHtmlAttr(s) {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
-function generateDotFromAlps(alpsData, labelMode) {
+function generateDotFromAlps(alpsData, labelMode, filterIds = null) {
     const descriptors = alpsData.alps?.descriptor || [];
 
     // Get all transition targets (rt values) - these are the actual states
@@ -923,6 +961,18 @@ function generateDotFromAlps(alpsData, labelMode) {
 
     // States are descriptors that are referenced as rt targets
     const states = descriptors.filter(d => d.id && rtTargets.has(d.id));
+    const transitionEntries = transitions
+        .filter(trans => trans.id && trans.rt)
+        .map(trans => ({
+            trans,
+            targetState: trans.rt.replace('#', ''),
+            sourceStates: findSourceStatesForTransition(trans.id, descriptors)
+        }));
+    const diagramNodeIds = new Set(rtTargets);
+    transitionEntries.forEach(entry => {
+        entry.sourceStates.forEach(sourceState => diagramNodeIds.add(sourceState));
+    });
+    const diagramNodes = descriptors.filter(d => d.id && diagramNodeIds.has(d.id));
 
     const getLabel = (descriptor) => {
         if (labelMode === 'title') {
@@ -931,11 +981,43 @@ function generateDotFromAlps(alpsData, labelMode) {
         return descriptor.id;
     };
 
+    let visibleStates = states;
+    let visibleTransitionEntries = transitionEntries;
+
+    if (filterIds && filterIds.size > 0) {
+        const visibleNodeIds = new Set();
+        diagramNodes.forEach(node => {
+            if (node.id && filterIds.has(node.id)) {
+                visibleNodeIds.add(node.id);
+            }
+        });
+        transitionEntries.forEach(entry => {
+            if (filterIds.has(entry.trans.id)) {
+                visibleNodeIds.add(entry.targetState);
+                entry.sourceStates.forEach(sourceState => visibleNodeIds.add(sourceState));
+            }
+        });
+
+        visibleStates = diagramNodes.filter(node => node.id && visibleNodeIds.has(node.id));
+        visibleTransitionEntries = transitionEntries
+            .map(entry => ({
+                ...entry,
+                sourceStates: entry.sourceStates.filter(sourceState =>
+                    visibleNodeIds.has(sourceState) && visibleNodeIds.has(entry.targetState)
+                )
+            }))
+            .filter(entry => entry.sourceStates.length > 0);
+
+        if (visibleStates.length === 0 && visibleTransitionEntries.length === 0) {
+            return '';
+        }
+    }
+
     let dot = 'digraph application_state_diagram {\\n' +
         '    graph [labelloc="t"; fontname="Helvetica"];\\n' +
         '    node [shape = box, style = "bold,filled" fillcolor="lightgray", margin="0.3,0.1"];\\n\\n';
 
-    states.forEach(state => {
+    visibleStates.forEach(state => {
         if (state.id) {
             const nodeId = escapeDotId(state.id);
             const nodeLabel = escapeDotLabel(getLabel(state));
@@ -947,24 +1029,21 @@ function generateDotFromAlps(alpsData, labelMode) {
 
     // Group transitions by (source, target) pair
     const edgeGroups = {};
-    transitions.forEach(trans => {
-        if (trans.id && trans.rt) {
-            const targetState = trans.rt.replace('#', '');
-            const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
-            const color = getTransitionColor(trans.type);
-            const transLabel = getLabel(trans);
-            sourceStates.forEach(sourceState => {
-                const key = sourceState + '\\t' + targetState;
-                if (!edgeGroups[key]) {
-                    edgeGroups[key] = { ids: [], labels: [], colors: [], types: [], titles: [] };
-                }
-                edgeGroups[key].ids.push(trans.id);
-                edgeGroups[key].labels.push(transLabel);
-                edgeGroups[key].colors.push(color);
-                edgeGroups[key].types.push(trans.type || '');
-                edgeGroups[key].titles.push(trans.title || trans.id);
-            });
-        }
+    visibleTransitionEntries.forEach(entry => {
+        const trans = entry.trans;
+        const color = getTransitionColor(trans.type);
+        const transLabel = getLabel(trans);
+        entry.sourceStates.forEach(sourceState => {
+            const key = sourceState + '\\t' + entry.targetState;
+            if (!edgeGroups[key]) {
+                edgeGroups[key] = { ids: [], labels: [], colors: [], types: [], titles: [] };
+            }
+            edgeGroups[key].ids.push(trans.id);
+            edgeGroups[key].labels.push(transLabel);
+            edgeGroups[key].colors.push(color);
+            edgeGroups[key].types.push(trans.type || '');
+            edgeGroups[key].titles.push(trans.title || trans.id);
+        });
     });
 
     // Render grouped edges with HTML TABLE labels
@@ -989,7 +1068,7 @@ function generateDotFromAlps(alpsData, labelMode) {
     });
 
     dot += '\\n';
-    states.forEach(state => {
+    visibleStates.forEach(state => {
         if (state.id) {
             const nodeId = escapeDotId(state.id);
             const nodeLabel = escapeDotLabel(getLabel(state));
@@ -1038,7 +1117,11 @@ async function regenerateSvg(labelMode) {
     svgGraph.innerHTML = '<p>Regenerating diagram...</p>';
 
     try {
-        const dotContent = generateDotFromAlps(alpsData, labelMode);
+        const dotContent = generateDotFromAlps(alpsData, labelMode, isTagOnlyMode() ? getSelectedDescriptorIds() : null);
+        if (!dotContent) {
+            svgGraph.innerHTML = '<p class="empty-diagram-message">No diagram nodes match the selected tags.</p>';
+            return;
+        }
         const vizInstance = await Viz.instance();
         const svgString = vizInstance.renderString(dotContent, { format: 'svg' });
         svgGraph.innerHTML = svgString;
@@ -1065,6 +1148,13 @@ document.querySelectorAll('input[name="labelMode"]').forEach(radio => {
         regenerateSvg(this.value).then(() => publishUrlState());
     });
 });
+
+const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+if (tagOnlyCheckbox) {
+    tagOnlyCheckbox.addEventListener('change', function() {
+        regenerateSvg(getCurrentLabelMode()).then(() => publishUrlState());
+    });
+}
 
 // Size mode toggle - keep selector position stable
 document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
@@ -1147,11 +1237,17 @@ async function applyUrlState(state) {
         const nextState = state || readUrlState();
         const selectedTags = Array.isArray(nextState.tag) ? nextState.tag : [];
         currentDescriptorHash = nextState.hash || '';
+        const wasTagOnlyMode = isTagOnlyMode();
 
         document.querySelectorAll('.tag-trigger-checkbox').forEach(checkbox => {
             const tag = checkbox.getAttribute('data-tag');
             checkbox.checked = Boolean(tag && selectedTags.includes(tag));
         });
+        updateTagOnlyControl();
+        const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+        if (tagOnlyCheckbox) {
+            tagOnlyCheckbox.checked = Boolean(nextState.tagOnly && selectedTags.length > 0);
+        }
 
         if (nextState.size) {
             applySizeMode(nextState.size, true);
@@ -1160,7 +1256,7 @@ async function applyUrlState(state) {
         const currentLabelMode = getCurrentLabelMode();
         const labelRadio = document.querySelector('input[name="labelMode"][value="' + nextState.label + '"]');
         if (labelRadio) labelRadio.checked = true;
-        if (currentLabelMode !== nextState.label) {
+        if (currentLabelMode !== nextState.label || wasTagOnlyMode || isTagOnlyMode()) {
             await regenerateSvg(nextState.label);
         }
 
@@ -1201,8 +1297,7 @@ document.addEventListener('DOMContentLoaded', autoSelectSizeMode);
 window.addEventListener('resize', autoSelectSizeMode);
 </script>
 </body></html>`;
-                    const blob = new Blob([html], { type: 'text/html' });
-                    return URL.createObjectURL(blob);
+                    return { html };
                 } catch (vizError) {
                     console.error('Viz.js rendering error:', vizError);
                     throw new Error(`Viz.js rendering failed: ${vizError.message}`);
@@ -1213,8 +1308,7 @@ window.addEventListener('resize', autoSelectSizeMode);
             const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>ALPS Diagram - Error</title>
 <style>body{margin:0;padding:20px;background:#f8f9fa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif} .container{background:#fff;border-radius:8px;box-shadow:0 2px 10px rgba(0,0,0,0.1);padding:20px;} .error{color:#dc3545;}</style>
 </head><body><div class="container"><div class="error"><strong>Diagram generation failed:</strong><br>Viz.js library not available after 5 seconds. Check network connection and try refreshing the page.</div></div></body></html>`;
-            const blob = new Blob([html], { type: 'text/html' });
-            return URL.createObjectURL(blob);
+            return { html };
         } catch (error) {
             throw new Error(`Alps2dot generation failed: ${error.message}`);
         }

--- a/docs/js/scripts.js
+++ b/docs/js/scripts.js
@@ -1,5 +1,5 @@
 import { SEMANTIC_TERMS } from './semanticTerms.js';
-import { DiagramAdapterManager } from './diagramAdapters.js';
+import { DiagramAdapterManager } from './diagramAdapters.js?v=tag-filter-20260606b';
 
 class AlpsEditor {
     constructor() {
@@ -430,7 +430,7 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             this.debugLog(`Using ${this.adapterManager.getCurrentAdapter().getName()} for diagram generation`);
 
             // Use the adapter manager to generate diagram
-            const url = await this.adapterManager.generateDiagram(content, fileType);
+            const diagram = await this.adapterManager.generateDiagram(content, fileType);
 
             const iframe = document.getElementById('preview-frame');
             // Apply view mode after iframe loads
@@ -439,7 +439,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
                 this.applyViewMode(mode);
                 this.applyDiagramUrlStateToFrame();
             };
-            iframe.src = url;
+            if (diagram && typeof diagram === 'object' && typeof diagram.html === 'string') {
+                iframe.removeAttribute('src');
+                iframe.srcdoc = diagram.html;
+            } else {
+                iframe.removeAttribute('srcdoc');
+                iframe.src = diagram;
+            }
             this.debugLog('Preview updated');
             this.updateValidationMark(true);
             this.displayErrors([]);
@@ -480,6 +486,7 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         return {
             view: ['document', 'diagram', 'preview'].includes(rawView) ? rawView : this.getDefaultViewMode(),
             tag: this.getTagsFromValues(params.getAll('tag')),
+            tagOnly: params.get('tagOnly') === '1',
             label: rawLabel === 'title' ? 'title' : 'id',
             size: this.normalizeSizeMode(params.get('size')),
             hash: window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : ''
@@ -500,6 +507,12 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         url.searchParams.delete('tag');
         if (Array.isArray(state.tag) && state.tag.length > 0) {
             url.searchParams.set('tag', state.tag.join(','));
+        }
+
+        if (state.tagOnly) {
+            url.searchParams.set('tagOnly', '1');
+        } else {
+            url.searchParams.delete('tagOnly');
         }
 
         if (state.label === 'title') {
@@ -523,6 +536,7 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         const state = this.readSharedUrlState();
         return {
             tag: state.tag,
+            tagOnly: state.tagOnly,
             label: state.label,
             size: state.size,
             hash: state.hash

--- a/packages/app-state-diagram/src/generator/html-generator.ts
+++ b/packages/app-state-diagram/src/generator/html-generator.ts
@@ -85,11 +85,12 @@ a{cursor:pointer;}
 #svg-container{display:flex;overflow-x:scroll;margin:20px 0;}
 #svg-graph{flex-shrink:0;text-align:center;}
 #svg-graph svg{display:block;max-width:none;}
-#svg-container.fit-width #svg-graph svg{max-width:100% !important;width:100% !important;height:auto !important;}
+#svg-container.fit-width #svg-graph svg{max-width:100% !important;height:auto !important;}
 #svg-container.fit-width #svg-graph{flex-shrink:1;width:100%;}
 #svg-container.half-size #svg-graph svg{max-width:60% !important;width:60% !important;height:auto !important;}
 #svg-container.half-size #svg-graph{flex-shrink:0;}
 h1,h2{margin-top:0;}
+.empty-diagram-message{color:#666;text-align:center;margin:30px 0;}
 /* Legend */
 .legend{display:flex;gap:20px;margin:20px 0;flex-wrap:wrap;}
 table .legend{background-color:transparent;padding:0;margin:0;display:inline-flex;align-items:center;}
@@ -146,6 +147,8 @@ td a:hover{text-decoration:underline;}
 .selector-option{margin-right:15px;display:inline-block;cursor:pointer;}
 .selector-option label{cursor:pointer;}
 .tag-trigger-checkbox{margin-right:3px;}
+.tag-only-option{border-left:1px solid #d0d7de;padding-left:12px;margin-left:4px;}
+.tag-only-checkbox{margin-right:3px;}
 /* Meta container for def, rt, tag */
 .meta-container{display:flex;flex-direction:column;gap:4px;}
 .meta-container br{display:none;}
@@ -309,7 +312,9 @@ document.addEventListener('DOMContentLoaded', function() {
         <span class="selector-option"><input type="radio" name="sizeMode" value="half"><label> Compact</label></span>
         <span class="selector-option"><input type="radio" name="sizeMode" value="fit"><label> Fit to width</label></span>
     </div>
-${tagSelectorHtml ? `    <div class="selector-row">${tagSelectorHtml}</div>` : ''}
+${tagSelectorHtml ? `    <div class="selector-row">${tagSelectorHtml}
+        <span class="selector-option tag-only-option"><input type="checkbox" id="tag-only-mode" class="tag-only-checkbox" disabled><label for="tag-only-mode"> Show selected tags only</label></span>
+    </div>` : ''}
 </div>
 ${tableHtml}
 ${linksHtml}
@@ -357,6 +362,7 @@ const readUrlState = () => {
     const params = new URLSearchParams(window.location.search);
     return {
         tag: getTagsFromValues(params.getAll('tag')),
+        tagOnly: params.get('tagOnly') === '1',
         label: params.get('label') === 'title' ? 'title' : 'id',
         size: normalizeSizeMode(params.get('size')),
         hash: getCurrentHash()
@@ -366,6 +372,7 @@ const readUrlState = () => {
 const collectUrlState = () => {
     return {
         tag: getSelectedTags(),
+        tagOnly: isTagOnlyMode(),
         label: getCurrentLabelMode(),
         size: getCurrentSizeMode(),
         hash: currentDescriptorHash || getCurrentHash()
@@ -377,6 +384,11 @@ const replaceUrlState = (state) => {
     url.searchParams.delete('tag');
     if (state.tag.length > 0) {
         url.searchParams.set('tag', state.tag.join(','));
+    }
+    if (state.tagOnly) {
+        url.searchParams.set('tagOnly', '1');
+    } else {
+        url.searchParams.delete('tagOnly');
     }
     if (state.label === 'title') {
         url.searchParams.set('label', 'title');
@@ -395,7 +407,6 @@ const replaceUrlState = (state) => {
 
 const publishUrlState = () => {
     if (isApplyingUrlState) return;
-    hasExplicitSizeMode = true;
     const state = collectUrlState();
     if (window.parent !== window) {
         window.parent.postMessage({ type: 'diagramStateChanged', state }, '*');
@@ -444,11 +455,27 @@ const setupTagEventListener = (eventName, ids, color, defaultColor = 'lightgrey'
     document.addEventListener('tagoff-' + eventName, () => changeColor(true));
 };
 
+const isTagOnlyMode = () => {
+    const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+    return Boolean(tagOnlyCheckbox && tagOnlyCheckbox.checked && getSelectedTags().length > 0);
+};
+
+const updateTagOnlyControl = () => {
+    const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+    if (!tagOnlyCheckbox) return;
+    const hasSelectedTags = getSelectedTags().length > 0;
+    tagOnlyCheckbox.disabled = !hasSelectedTags;
+    if (!hasSelectedTags) {
+        tagOnlyCheckbox.checked = false;
+    }
+};
+
 const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
-        checkbox.addEventListener('change', function() {
-            applySelectedTagsToDiagram();
+        checkbox.addEventListener('change', async function() {
+            updateTagOnlyControl();
+            await regenerateSvg(getCurrentLabelMode());
             publishUrlState();
         });
     });
@@ -474,15 +501,38 @@ Object.keys(tagDescriptorMap).forEach(tag => {
 });
 
 setupTagTrigger();
+updateTagOnlyControl();
 
 // Label mode switching
 window.alpsData = ${escapeJsonForScript(alpsData)};
 
-function generateDotFromAlps(data, labelMode) {
+function getSelectedDescriptorIds() {
+    const ids = new Set();
+    getSelectedTags().forEach(tag => {
+        (tagDescriptorMap[tag] || []).forEach(id => {
+            if (id) ids.add(id);
+        });
+    });
+    return ids;
+}
+
+function generateDotFromAlps(data, labelMode, filterIds = null) {
     const descriptors = data.alps?.descriptor || [];
     const transitions = descriptors.filter(d => d.type && d.rt);
     const rtTargets = new Set(transitions.map(t => t.rt.replace('#', '')));
     const states = descriptors.filter(d => d.id && rtTargets.has(d.id));
+    const transitionEntries = transitions
+        .filter(trans => trans.id && trans.rt)
+        .map(trans => ({
+            trans,
+            targetState: trans.rt.replace('#', ''),
+            sourceStates: findSourceStatesForTransition(trans.id, descriptors)
+        }));
+    const diagramNodeIds = new Set(rtTargets);
+    transitionEntries.forEach(entry => {
+        entry.sourceStates.forEach(sourceState => diagramNodeIds.add(sourceState));
+    });
+    const diagramNodes = descriptors.filter(d => d.id && diagramNodeIds.has(d.id));
 
     const getLabel = (descriptor) => {
         if (labelMode === 'title') {
@@ -491,11 +541,43 @@ function generateDotFromAlps(data, labelMode) {
         return descriptor.id;
     };
 
+    let visibleStates = states;
+    let visibleTransitionEntries = transitionEntries;
+
+    if (filterIds && filterIds.size > 0) {
+        const visibleNodeIds = new Set();
+        diagramNodes.forEach(node => {
+            if (node.id && filterIds.has(node.id)) {
+                visibleNodeIds.add(node.id);
+            }
+        });
+        transitionEntries.forEach(entry => {
+            if (filterIds.has(entry.trans.id)) {
+                visibleNodeIds.add(entry.targetState);
+                entry.sourceStates.forEach(sourceState => visibleNodeIds.add(sourceState));
+            }
+        });
+
+        visibleStates = diagramNodes.filter(node => node.id && visibleNodeIds.has(node.id));
+        visibleTransitionEntries = transitionEntries
+            .map(entry => ({
+                ...entry,
+                sourceStates: entry.sourceStates.filter(sourceState =>
+                    visibleNodeIds.has(sourceState) && visibleNodeIds.has(entry.targetState)
+                )
+            }))
+            .filter(entry => entry.sourceStates.length > 0);
+
+        if (visibleStates.length === 0 && visibleTransitionEntries.length === 0) {
+            return '';
+        }
+    }
+
     let dot = 'digraph application_state_diagram {\\n' +
         '    graph [labelloc="t"; fontname="Helvetica"];\\n' +
         '    node [shape = box, style = "bold,filled" fillcolor="lightgray", margin="0.3,0.1"];\\n\\n';
 
-    states.forEach(state => {
+    visibleStates.forEach(state => {
         if (state.id) {
             dot += '    ' + state.id + ' [margin=0.1, label="' + getLabel(state) + '", shape=box, URL="#' + state.id + '"]\\n';
         }
@@ -505,25 +587,22 @@ function generateDotFromAlps(data, labelMode) {
 
     // Group transitions by (source, target) pair
     const edgeGroups = {};
-    transitions.forEach(trans => {
-        if (trans.id && trans.rt) {
-            const targetState = trans.rt.replace('#', '');
-            const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
-            const color = getTransitionColor(trans.type);
-            const transLabel = getLabel(trans);
-            sourceStates.forEach(sourceState => {
-                const key = sourceState + '\\t' + targetState;
-                if (!edgeGroups[key]) {
-                    edgeGroups[key] = { ids: [], labels: [], colors: [], types: [], titles: [] };
-                }
-                const group = edgeGroups[key];
-                group.ids.push(trans.id);
-                group.labels.push(transLabel);
-                group.colors.push(color);
-                group.types.push(trans.type || '');
-                group.titles.push(trans.title || trans.id);
-            });
-        }
+    visibleTransitionEntries.forEach(entry => {
+        const trans = entry.trans;
+        const color = getTransitionColor(trans.type);
+        const transLabel = getLabel(trans);
+        entry.sourceStates.forEach(sourceState => {
+            const key = sourceState + '\\t' + entry.targetState;
+            if (!edgeGroups[key]) {
+                edgeGroups[key] = { ids: [], labels: [], colors: [], types: [], titles: [] };
+            }
+            const group = edgeGroups[key];
+            group.ids.push(trans.id);
+            group.labels.push(transLabel);
+            group.colors.push(color);
+            group.types.push(trans.type || '');
+            group.titles.push(trans.title || trans.id);
+        });
     });
 
     // Render grouped edges with HTML TABLE labels
@@ -549,7 +628,7 @@ function generateDotFromAlps(data, labelMode) {
     });
 
     dot += '\\n';
-    states.forEach(state => {
+    visibleStates.forEach(state => {
         if (state.id) {
             dot += '    ' + state.id + ' [label="' + getLabel(state) + '" URL="#' + state.id + '"]\\n';
         }
@@ -604,7 +683,11 @@ async function regenerateSvg(labelMode) {
     svgGraph.innerHTML = '<p>Regenerating diagram...</p>';
 
     try {
-        const dotContent = generateDotFromAlps(window.alpsData, labelMode);
+        const dotContent = generateDotFromAlps(window.alpsData, labelMode, isTagOnlyMode() ? getSelectedDescriptorIds() : null);
+        if (!dotContent) {
+            svgGraph.innerHTML = '<p class="empty-diagram-message">No diagram nodes match the selected tags.</p>';
+            return;
+        }
         const vizInstance = await Viz.instance();
         const svgString = vizInstance.renderString(dotContent, { format: 'svg' });
         svgGraph.innerHTML = svgString;
@@ -629,6 +712,13 @@ document.querySelectorAll('input[name="labelMode"]').forEach(radio => {
         regenerateSvg(this.value).then(() => publishUrlState());
     });
 });
+
+const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+if (tagOnlyCheckbox) {
+    tagOnlyCheckbox.addEventListener('change', function() {
+        regenerateSvg(getCurrentLabelMode()).then(() => publishUrlState());
+    });
+}
 
 // Size mode toggle - keep selector position stable
 document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
@@ -707,11 +797,17 @@ async function applyUrlState(state) {
         const nextState = state || readUrlState();
         const selectedTags = Array.isArray(nextState.tag) ? nextState.tag : [];
         currentDescriptorHash = nextState.hash || '';
+        const wasTagOnlyMode = isTagOnlyMode();
 
         document.querySelectorAll('.tag-trigger-checkbox').forEach(checkbox => {
             const tag = checkbox.getAttribute('data-tag');
             checkbox.checked = Boolean(tag && selectedTags.includes(tag));
         });
+        updateTagOnlyControl();
+        const tagOnlyCheckbox = document.getElementById('tag-only-mode');
+        if (tagOnlyCheckbox) {
+            tagOnlyCheckbox.checked = Boolean(nextState.tagOnly && selectedTags.length > 0);
+        }
 
         if (nextState.size) {
             applySizeMode(nextState.size, true);
@@ -720,7 +816,7 @@ async function applyUrlState(state) {
         const currentLabelMode = getCurrentLabelMode();
         const labelRadio = document.querySelector('input[name="labelMode"][value="' + nextState.label + '"]');
         if (labelRadio) labelRadio.checked = true;
-        if (currentLabelMode !== nextState.label) {
+        if (currentLabelMode !== nextState.label || wasTagOnlyMode || isTagOnlyMode()) {
             await regenerateSvg(nextState.label);
         }
 

--- a/packages/app-state-diagram/src/generator/html-generator.ts
+++ b/packages/app-state-diagram/src/generator/html-generator.ts
@@ -474,8 +474,13 @@ const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', async function() {
+            const wasTagOnlyMode = isTagOnlyMode();
             updateTagOnlyControl();
-            await regenerateSvg(getCurrentLabelMode());
+            if (wasTagOnlyMode || isTagOnlyMode()) {
+                await regenerateSvg(getCurrentLabelMode());
+            } else {
+                applySelectedTagsToDiagram();
+            }
             publishUrlState();
         });
     });
@@ -514,6 +519,19 @@ function getSelectedDescriptorIds() {
         });
     });
     return ids;
+}
+
+function escapeDotId(id) {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(id)) {
+        return id;
+    }
+    return '"' + id.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '\\\\"') + '"';
+}
+
+function escapeDotLabel(label) {
+    return label
+        .replace(/\\\\/g, '\\\\\\\\')
+        .replace(/"/g, '\\\\"');
 }
 
 function generateDotFromAlps(data, labelMode, filterIds = null) {
@@ -579,7 +597,9 @@ function generateDotFromAlps(data, labelMode, filterIds = null) {
 
     visibleStates.forEach(state => {
         if (state.id) {
-            dot += '    ' + state.id + ' [margin=0.1, label="' + getLabel(state) + '", shape=box, URL="#' + state.id + '"]\\n';
+            const nodeId = escapeDotId(state.id);
+            const nodeLabel = escapeDotLabel(getLabel(state));
+            dot += '    ' + nodeId + ' [margin=0.1, label="' + nodeLabel + '", shape=box, URL="#' + escapeDotLabel(state.id) + '"]\\n';
         }
     });
 
@@ -616,21 +636,23 @@ function generateDotFromAlps(data, labelMode, filterIds = null) {
 
         if (group.ids.length === 1) {
             const tableLabel = '<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="0"><TR><TD VALIGN="MIDDLE" HREF="#' + escapeHtmlAttr(group.ids[0]) + '" TOOLTIP="' + escapeHtmlAttr(group.titles[0]) + ' (' + group.types[0] + ')"><FONT COLOR="' + group.colors[0] + '">\\u25A0</FONT> ' + escapeHtmlLabel(group.labels[0]) + '</TD></TR></TABLE>';
-            dot += '    ' + sourceState + ' -> ' + targetState + ' [label=<' + tableLabel + '> URL="#' + escapeHtmlAttr(group.ids[0]) + '" fontsize=13 class="' + escapeHtmlAttr(group.ids[0]) + '" penwidth=1.3 color="' + edgeColor + '"];\\n';
+            dot += '    ' + escapeDotId(sourceState) + ' -> ' + escapeDotId(targetState) + ' [label=<' + tableLabel + '> URL="#' + escapeHtmlAttr(group.ids[0]) + '" fontsize=13 class="' + escapeHtmlAttr(group.ids[0]) + '" penwidth=1.3 color="' + edgeColor + '"];\\n';
         } else {
             let rows = '';
             for (let i = 0; i < group.ids.length; i++) {
                 rows += '<TR><TD VALIGN="MIDDLE" ALIGN="LEFT" HREF="#' + escapeHtmlAttr(group.ids[i]) + '" TOOLTIP="' + escapeHtmlAttr(group.titles[i]) + ' (' + group.types[i] + ')"><FONT COLOR="' + group.colors[i] + '">\\u25A0</FONT> ' + escapeHtmlLabel(group.labels[i]) + '</TD></TR>';
             }
             const tableLabel = '<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="0" CELLPADDING="0">' + rows + '</TABLE>';
-            dot += '    ' + sourceState + ' -> ' + targetState + ' [label=<' + tableLabel + '> URL="#' + escapeHtmlAttr(group.ids[0]) + '" fontsize=13 class="' + escapeHtmlAttr(group.ids[0]) + '" penwidth=1.3 color="' + edgeColor + '"];\\n';
+            dot += '    ' + escapeDotId(sourceState) + ' -> ' + escapeDotId(targetState) + ' [label=<' + tableLabel + '> URL="#' + escapeHtmlAttr(group.ids[0]) + '" fontsize=13 class="' + escapeHtmlAttr(group.ids[0]) + '" penwidth=1.3 color="' + edgeColor + '"];\\n';
         }
     });
 
     dot += '\\n';
     visibleStates.forEach(state => {
         if (state.id) {
-            dot += '    ' + state.id + ' [label="' + getLabel(state) + '" URL="#' + state.id + '"]\\n';
+            const nodeId = escapeDotId(state.id);
+            const nodeLabel = escapeDotLabel(getLabel(state));
+            dot += '    ' + nodeId + ' [label="' + nodeLabel + '" URL="#' + escapeDotLabel(state.id) + '"]\\n';
         }
     });
     dot += '\\n}';


### PR DESCRIPTION
## Summary
- Add a tag-only diagram mode that is enabled when one or more tags are selected.
- Regenerate DOT/SVG from only the selected tag-related nodes and links, with an empty-state message when nothing matches.
- Keep fit-to-width as shrink-only behavior and refresh the static docs preview path so the new controls render reliably.

## Validation
- pnpm -r build
- Manual in-app browser check at http://localhost:4173/?view=preview&size=original&tag=flow-review%2Citem


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "show selected tags only" filter for diagrams. When enabled, the diagram displays only states and transitions connected to your selected tags. An empty state message appears when no items match the filter. Filter preferences are preserved in shareable links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->