### PR TITLE
Add profile query/edit tools and tag-filtered diagrams to MCP server

### DIFF
--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -101,6 +101,7 @@ Verify: `/mcp` should show "alps" in the list.
 |------|-------------|
 | `alps_overview` | States, transitions (from/to), and tags at a glance |
 | `alps_search` | Filter descriptors by type, tag(s), or text; `format: markdown` returns a table (ID, Type, Title, Tags, Doc) for direct chat display |
+| `alps_tags` | Tags in use grouped by facet (actor/flow/feature/src/page, else domain) with usage counts; `vocabulary` joins each tag with its [tag vocabulary](tag-vocabulary.md) definition |
 | `alps_descriptor` | One descriptor in full — external docs and local `describedby` links resolved, containers, incoming/outgoing transitions |
 | `alps_paths` | Enumerate transition paths between two states |
 | `alps_set_doc` | Write descriptor documentation; large docs are auto-externalized to `alps/docs/<id>.md` and linked via `doc.href` |

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -101,7 +101,7 @@ Verify: `/mcp` should show "alps" in the list.
 |------|-------------|
 | `alps_overview` | States, transitions (from/to), and tags at a glance |
 | `alps_search` | Filter descriptors by type, tag(s), or text; `format: markdown` returns a table (ID, Type, Title, Tags, Doc) for direct chat display |
-| `alps_descriptor` | One descriptor in full — external docs resolved, containers, incoming/outgoing transitions |
+| `alps_descriptor` | One descriptor in full — external docs and local `describedby` links resolved, containers, incoming/outgoing transitions |
 | `alps_paths` | Enumerate transition paths between two states |
 | `alps_set_doc` | Write descriptor documentation; large docs are auto-externalized to `alps/docs/<id>.md` and linked via `doc.href` |
 | `alps_add_descriptor` | Create a new descriptor — nested or with `href` children; missing children are created automatically ("register name and age as person") |

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -88,7 +88,7 @@ Verify: `/mcp` should show "alps" in the list.
 
 | Tool | Description |
 |------|-------------|
-| `validate_alps` | Validate an ALPS profile |
+| `validate_alps` | Validate an ALPS profile (`vocabulary` additionally checks tags against a [tag vocabulary](tag-vocabulary.md) file — unknown tags are `W005` warnings) |
 | `alps2svg` | Generate an SVG diagram (`tag` filters to a tagged slice; `output` writes to a file and returns the path) |
 | `alps2mermaid` | Generate a Mermaid diagram — renders natively in GitHub, claude.ai, and VS Code (`tag` filters to a tagged slice) |
 | `validate_openapi` | Validate an OpenAPI document |

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -84,9 +84,28 @@ Verify: `/mcp` should show "alps" in the list.
 
 ### Available Tools
 
-- `validate_alps` - Validate ALPS profile
-- `alps2svg` - Generate SVG diagram
-- `alps_guide` - Get ALPS best practices
+**Convert and validate:**
+
+| Tool | Description |
+|------|-------------|
+| `validate_alps` | Validate an ALPS profile |
+| `alps2svg` | Generate an SVG diagram (`tag` filters to a tagged slice; `output` writes to a file and returns the path) |
+| `alps2mermaid` | Generate a Mermaid diagram — renders natively in GitHub, claude.ai, and VS Code (`tag` filters to a tagged slice) |
+| `validate_openapi` | Validate an OpenAPI document |
+| `crawl_and_extract_alps` | Extract an ALPS draft from a website |
+| `alps_guide` | Get ALPS best practices |
+
+**Query and edit profiles:**
+
+| Tool | Description |
+|------|-------------|
+| `alps_overview` | States, transitions (from/to), and tags at a glance |
+| `alps_search` | Filter descriptors by type, tag(s), or text; `format: markdown` returns a table (ID, Type, Title, Tags, Doc) for direct chat display |
+| `alps_descriptor` | One descriptor in full — external docs resolved, containers, incoming/outgoing transitions |
+| `alps_paths` | Enumerate transition paths between two states |
+| `alps_set_doc` | Write descriptor documentation; large docs are auto-externalized to `alps/docs/<id>.md` and linked via `doc.href` |
+
+**Tip — view a tagged slice entirely in chat:** ask for `alps2mermaid` with `tag` (the diagram renders natively) plus `alps_search` with the same tags and `format: markdown` (the descriptor table).
 
 ## llms.txt (Any LLM)
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -104,6 +104,7 @@ Verify: `/mcp` should show "alps" in the list.
 | `alps_descriptor` | One descriptor in full — external docs resolved, containers, incoming/outgoing transitions |
 | `alps_paths` | Enumerate transition paths between two states |
 | `alps_set_doc` | Write descriptor documentation; large docs are auto-externalized to `alps/docs/<id>.md` and linked via `doc.href` |
+| `alps_add_descriptor` | Create a new descriptor — nested or with `href` children; missing children are created automatically ("register name and age as person") |
 
 **Tip — view a tagged slice entirely in chat:** ask for `alps2mermaid` with `tag` (the diagram renders natively) plus `alps_search` with the same tags and `format: markdown` (the descriptor table).
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -105,6 +105,7 @@ Verify: `/mcp` should show "alps" in the list.
 | `alps_paths` | Enumerate transition paths between two states |
 | `alps_set_doc` | Write descriptor documentation; large docs are auto-externalized to `alps/docs/<id>.md` and linked via `doc.href` |
 | `alps_add_descriptor` | Create a new descriptor — nested or with `href` children; missing children are created automatically ("register name and age as person") |
+| `alps_set_tags` | Add/remove tags in a descriptor's space-separated `tag` attribute — kept tags preserve their order |
 
 **Tip — view a tagged slice entirely in chat:** ask for `alps2mermaid` with `tag` (the diagram renders natively) plus `alps_search` with the same tags and `format: markdown` (the descriptor table).
 

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -106,6 +106,7 @@ Verify: `/mcp` should show "alps" in the list.
 | `alps_set_doc` | Write descriptor documentation; large docs are auto-externalized to `alps/docs/<id>.md` and linked via `doc.href` |
 | `alps_add_descriptor` | Create a new descriptor — nested or with `href` children; missing children are created automatically ("register name and age as person") |
 | `alps_set_tags` | Add/remove tags in a descriptor's space-separated `tag` attribute — kept tags preserve their order |
+| `alps_rename` | Rename a descriptor and update all local `href`/`rt` `#fragment` references across the profile |
 
 **Tip — view a tagged slice entirely in chat:** ask for `alps2mermaid` with `tag` (the diagram renders natively) plus `alps_search` with the same tags and `format: markdown` (the descriptor table).
 

--- a/docs/tag-vocabulary.md
+++ b/docs/tag-vocabulary.md
@@ -1,0 +1,136 @@
+# ALPS Tag Vocabulary
+
+A convention for making ALPS tags dereferenceable: every tag used in a
+profile is defined in one HTML document that both humans and machines can
+read.
+
+## Motivation
+
+ALPS descriptors point at shared meaning through `def` — a `title` field
+referencing `https://schema.org/title` is not just a string, it is an
+identifier you can dereference and read. Tags deserve the same treatment.
+A profile's space-separated `tag` attributes form a faceted taxonomy
+(`flow-customer-purchase`, `actor-admin`, `checkout`), but each tag is an
+opaque string: a typo like `flow-purchace` silently creates a new category,
+and nothing explains what `flow-customer-purchase` actually promises.
+
+The fix is a vocabulary file. Each tag becomes a URI fragment in one HTML
+document — `tags.html#flow-customer-purchase` — which serves as:
+
+- **Documentation** for humans: open it in a browser, read the definitions.
+- **Ground truth** for tooling: validators flag tags that are not defined,
+  and listings join usage with definitions.
+
+## The vocabulary file
+
+`tags.html` lives next to the profile and is linked from it:
+
+```json
+{
+  "alps": {
+    "link": [{ "rel": "tag", "href": "tags.html" }]
+  }
+}
+```
+
+Profiles may equivalently announce the vocabulary with an ALPS `ext`
+element (`{"ext": [{"id": "tag-vocabulary", "href": "tags.html"}]}`) when a
+link relation is impractical.
+
+## HTML structure
+
+Each facet is a `<section data-facet="...">` containing a definition list.
+Each tag is a `<dt>` whose `id` is the tag value, followed by a `<dd>`
+description:
+
+```html
+<section data-facet="flow">
+  <dl>
+    <dt id="flow-customer-purchase"
+        data-actor="customer"
+        data-spans="feature-browse feature-purchase">Customer purchase</dt>
+    <dd>
+      A customer finds a product, adds it to the cart, and completes an order.
+      <p data-role="goal">The order confirmation state is reached and the
+      order is recorded.</p>
+      <p data-role="evidence">Order appears in the customer's history.</p>
+    </dd>
+  </dl>
+</section>
+```
+
+Conventions:
+
+- **`id` on `<dt>`**: the `id` attribute of each `<dt>` is the tag value.
+  Tooling treats *only* `<dt>` ids as tag definitions, so keep ids for other
+  purposes off `<dt>` elements. Tag values become URI fragments:
+  `tags.html#flow-customer-purchase`.
+- **`<dt>` text content** is the tag's human-readable title.
+- **Data attributes** carry machine-readable relations: flows declare their
+  `data-actor` and the features they span via `data-spans` (space-separated
+  tag values).
+- **Flow descriptions** may carry `<p data-role="goal">` (the semantic
+  postcondition that makes the flow count as completed) and
+  `<p data-role="evidence">` (how completion is observed).
+
+## Facet prefix registry
+
+| Prefix | Facet | Meaning | Example |
+|--------|-------|---------|---------|
+| `actor-` | actor | Who performs the behavior | `actor-customer` |
+| `flow-` | flow | A business journey with a goal condition | `flow-customer-purchase` |
+| `feature-` | feature | Feature area / coverage bucket | `feature-purchase` |
+| `src-` | src | Information source the descriptor was derived from | `src-entity` |
+| `page-` | page | HTML screen classification | `page-list` |
+| (none) | domain | Domain vocabulary | `checkout`, `catalog` |
+
+## Complete example
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Store Tag Vocabulary</title></head>
+<body>
+  <h1>Store Tag Vocabulary</h1>
+  <section data-facet="actor">
+    <dl>
+      <dt id="actor-customer">Customer</dt>
+      <dd>A shopper using the storefront.</dd>
+    </dl>
+  </section>
+  <section data-facet="flow">
+    <dl>
+      <dt id="flow-customer-purchase" data-actor="customer"
+          data-spans="feature-browse feature-purchase">Customer purchase</dt>
+      <dd>A customer finds a product and completes an order.
+        <p data-role="goal">Order confirmation reached; order recorded.</p>
+      </dd>
+    </dl>
+  </section>
+  <section data-facet="feature">
+    <dl>
+      <dt id="feature-browse">Browse</dt><dd>Product discovery screens.</dd>
+      <dt id="feature-purchase">Purchase</dt><dd>Cart and checkout.</dd>
+    </dl>
+  </section>
+  <section data-facet="domain">
+    <dl>
+      <dt id="checkout">Checkout</dt><dd>Order placement vocabulary.</dd>
+    </dl>
+  </section>
+</body>
+</html>
+```
+
+## Tooling
+
+The MCP server consumes the vocabulary file:
+
+- **`validate_alps`** with `vocabulary: "tags.html"` checks every tag used
+  in the profile against the `<dt>` ids. Tags not defined in the vocabulary
+  are reported as `W005` warnings ("Unknown tag ..."), and tags defined but
+  never used are listed informationally — so typos surface instead of
+  silently creating new categories.
+- **`alps_tags`** lists the tags in use, grouped by facet with usage counts;
+  given `vocabulary`, each tag is joined with its definition (`defined`,
+  `title`).

--- a/packages/app-state-diagram/package.json
+++ b/packages/app-state-diagram/package.json
@@ -17,7 +17,8 @@
     ".": "./dist/asd.js",
     "./parser/*": "./dist/parser/*",
     "./validator/*": "./dist/validator/*",
-    "./generator/*": "./dist/generator/*"
+    "./generator/*": "./dist/generator/*",
+    "./graph/*": "./dist/graph/*"
   },
   "bin": {
     "asd": "dist/asd.js"

--- a/packages/app-state-diagram/package.json
+++ b/packages/app-state-diagram/package.json
@@ -18,7 +18,8 @@
     "./parser/*": "./dist/parser/*",
     "./validator/*": "./dist/validator/*",
     "./generator/*": "./dist/generator/*",
-    "./graph/*": "./dist/graph/*"
+    "./graph/*": "./dist/graph/*",
+    "./resolver/*": "./dist/resolver/*"
   },
   "bin": {
     "asd": "dist/asd.js"

--- a/packages/app-state-diagram/src/generator/dot-generator.test.ts
+++ b/packages/app-state-diagram/src/generator/dot-generator.test.ts
@@ -550,4 +550,38 @@ describe('DotGenerator', () => {
     expect(dot).toContain('color="#000000"');
   });
 
+  it('should render the induced subgraph for filter ids', () => {
+    const alps: AlpsDocument = {
+      alps: {
+        descriptor: [
+          { id: 'Home', descriptor: [{ href: '#goCart' }, { href: '#goAdmin' }] },
+          { id: 'Cart' },
+          { id: 'AdminTop' },
+          { id: 'goCart', type: 'safe', rt: '#Cart', tag: 'cart' },
+          { id: 'goAdmin', type: 'safe', rt: '#AdminTop', tag: 'admin' }
+        ]
+      }
+    };
+
+    const dot = generateDot(alps, 'id', new Set(['goCart']));
+
+    expect(dot).toContain('Home -> Cart');
+    expect(dot).not.toContain('AdminTop');
+    expect(dot).not.toContain('goAdmin');
+  });
+
+  it('should return an empty DOT fragment when filter ids match no states', () => {
+    const alps: AlpsDocument = {
+      alps: {
+        descriptor: [
+          { id: 'Home', descriptor: [{ href: '#goCart' }] },
+          { id: 'Cart' },
+          { id: 'goCart', type: 'safe', rt: '#Cart' }
+        ]
+      }
+    };
+
+    expect(generateDot(alps, 'id', new Set(['missing']))).toBe('');
+  });
+
 });

--- a/packages/app-state-diagram/src/generator/dot-generator.ts
+++ b/packages/app-state-diagram/src/generator/dot-generator.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
+import { extractGraph, computeVisibleNodeIds } from '../graph/graph';
 
 export type LabelMode = 'id' | 'title';
 
@@ -58,7 +59,7 @@ function escapeHtmlAttr(value: string): string {
 /**
  * Generate DOT content from ALPS data
  */
-export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id'): string {
+export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id', filterIds?: Set<string> | null): string {
   const descriptors = alpsData.alps?.descriptor || [];
 
   // Get all transition targets (rt values) - these are the actual states
@@ -72,6 +73,17 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
   if (states.length === 0) {
     // Exclude descriptors that look like transitions (have safe/unsafe/idempotent type)
     states = descriptors.filter(d => d.id && (!d.type || d.type === 'semantic'));
+  }
+
+  // Tag filter: induced subgraph over tagged nodes and tagged transitions' endpoints
+  let visible: Set<string> | null = null;
+  if (filterIds && filterIds.size > 0) {
+    visible = computeVisibleNodeIds(extractGraph(alpsData), filterIds);
+    const visibleIds = visible;
+    states = descriptors.filter(d => d.id && visibleIds.has(d.id));
+    if (states.length === 0) {
+      return '';
+    }
   }
 
   const getLabel = (descriptor: AlpsDescriptor): string => {
@@ -106,7 +118,14 @@ export function generateDot(alpsData: AlpsDocument, labelMode: LabelMode = 'id')
   for (const trans of transitions) {
     if (trans.id) {
       const targetState = trans.rt!.replace('#', '');
-      const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
+      if (visible && !visible.has(targetState)) {
+        continue;
+      }
+      let sourceStates = findSourceStatesForTransition(trans.id, descriptors);
+      if (visible) {
+        const visibleIds = visible;
+        sourceStates = sourceStates.filter(source => visibleIds.has(source));
+      }
       const color = getTransitionColor(trans.type);
       const transLabel = getLabel(trans);
       for (const sourceState of sourceStates) {

--- a/packages/app-state-diagram/src/generator/mermaid-generator.test.ts
+++ b/packages/app-state-diagram/src/generator/mermaid-generator.test.ts
@@ -284,3 +284,38 @@ describe('MermaidGenerator', () => {
     });
   });
 });
+
+describe('generateMermaid with tag filter', () => {
+  const doc = {
+    alps: {
+      descriptor: [
+        { id: 'Home', type: 'semantic' as const, descriptor: [{ href: '#goCart' }, { href: '#goAdmin' }] },
+        { id: 'Cart', type: 'semantic' as const },
+        { id: 'AdminTop', type: 'semantic' as const },
+        { id: 'goCart', type: 'safe' as const, rt: '#Cart', tag: 'cart' },
+        { id: 'goAdmin', type: 'safe' as const, rt: '#AdminTop', tag: 'admin' },
+      ],
+    },
+  };
+
+  it('renders the induced subgraph for the filter ids', () => {
+    const mermaid = generateMermaid(doc, new Set(['goCart', 'Home', 'Cart']));
+    expect(mermaid).toContain('Home --> Cart');
+    expect(mermaid).not.toContain('AdminTop');
+    expect(mermaid).not.toContain('goAdmin');
+  });
+
+  it('pulls in endpoints of a tagged transition even when states are unfiltered', () => {
+    const mermaid = generateMermaid(doc, new Set(['goAdmin']));
+    expect(mermaid).toContain('Home --> AdminTop');
+    expect(mermaid).not.toContain('Cart');
+  });
+
+  it('returns an empty string when nothing matches', () => {
+    expect(generateMermaid(doc, new Set(['nothing']))).toBe('');
+  });
+
+  it('is unchanged when no filter is given', () => {
+    expect(generateMermaid(doc)).toContain('goAdmin');
+  });
+});

--- a/packages/app-state-diagram/src/generator/mermaid-generator.test.ts
+++ b/packages/app-state-diagram/src/generator/mermaid-generator.test.ts
@@ -289,7 +289,8 @@ describe('generateMermaid with tag filter', () => {
   const doc = {
     alps: {
       descriptor: [
-        { id: 'Home', type: 'semantic' as const, descriptor: [{ href: '#goCart' }, { href: '#goAdmin' }] },
+        { id: 'Home', type: 'semantic' as const, descriptor: [{ href: '#summary' }, { href: '#goCart' }, { href: '#goAdmin' }] },
+        { id: 'summary', type: 'semantic' as const },
         { id: 'Cart', type: 'semantic' as const },
         { id: 'AdminTop', type: 'semantic' as const },
         { id: 'goCart', type: 'safe' as const, rt: '#Cart', tag: 'cart' },
@@ -301,6 +302,7 @@ describe('generateMermaid with tag filter', () => {
   it('renders the induced subgraph for the filter ids', () => {
     const mermaid = generateMermaid(doc, new Set(['goCart', 'Home', 'Cart']));
     expect(mermaid).toContain('Home --> Cart');
+    expect(mermaid).toContain('⬜ summary');
     expect(mermaid).not.toContain('AdminTop');
     expect(mermaid).not.toContain('goAdmin');
   });

--- a/packages/app-state-diagram/src/generator/mermaid-generator.ts
+++ b/packages/app-state-diagram/src/generator/mermaid-generator.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
+import { extractGraph, computeVisibleNodeIds } from '../graph/graph';
 
 const EMOJI = {
   semantic: '⬜',
@@ -16,7 +17,7 @@ const EMOJI = {
 /**
  * Generate Mermaid classDiagram content from ALPS data
  */
-export function generateMermaid(alpsData: AlpsDocument): string {
+export function generateMermaid(alpsData: AlpsDocument, filterIds?: Set<string> | null): string {
   const descriptors = alpsData.alps?.descriptor || [];
 
   // Get all transition targets (rt values) - these are the actual states
@@ -29,6 +30,17 @@ export function generateMermaid(alpsData: AlpsDocument): string {
   // If there are no transitions, include all semantic descriptors as states
   if (states.length === 0) {
     states = descriptors.filter(d => d.id && (!d.type || d.type === 'semantic'));
+  }
+
+  // Tag filter: induced subgraph over tagged nodes and tagged transitions' endpoints
+  let visible: Set<string> | null = null;
+  if (filterIds && filterIds.size > 0) {
+    visible = computeVisibleNodeIds(extractGraph(alpsData), filterIds);
+    const visibleIds = visible;
+    states = descriptors.filter(d => d.id && visibleIds.has(d.id));
+    if (states.length === 0) {
+      return '';
+    }
   }
 
   // Build a map of descriptor id to descriptor for quick lookup
@@ -49,7 +61,18 @@ export function generateMermaid(alpsData: AlpsDocument): string {
     mermaid += `    class ${state.id} {\n`;
 
     // Get child descriptors and sort by type: semantic, safe, unsafe, idempotent
-    const children = getChildDescriptors(state, descriptorMap);
+    let children = getChildDescriptors(state, descriptorMap);
+    if (visible) {
+      // Keep semantic members (the state's shape); drop transitions leading outside the slice
+      const visibleIds = visible;
+      children = children.filter(child => {
+        if (!child.type || child.type === 'semantic') {
+          return true;
+        }
+        const target = descriptorMap.get(child.id)?.rt?.replace('#', '');
+        return target !== undefined && visibleIds.has(target);
+      });
+    }
     const sorted = sortByType(children);
 
     for (const child of sorted) {
@@ -67,7 +90,14 @@ export function generateMermaid(alpsData: AlpsDocument): string {
     if (!trans.id || !trans.rt) continue;
 
     const targetState = trans.rt.replace('#', '');
-    const sourceStates = findSourceStatesForTransition(trans.id, descriptors);
+    if (visible && !visible.has(targetState)) {
+      continue;
+    }
+    let sourceStates = findSourceStatesForTransition(trans.id, descriptors);
+    if (visible) {
+      const visibleIds = visible;
+      sourceStates = sourceStates.filter(source => visibleIds.has(source));
+    }
     const emoji = getEmoji(trans.type);
 
     for (const sourceState of sourceStates) {

--- a/packages/app-state-diagram/src/graph/graph.test.ts
+++ b/packages/app-state-diagram/src/graph/graph.test.ts
@@ -1,4 +1,4 @@
-import { extractGraph, findPaths, formatPath, findContainers } from './graph';
+import { extractGraph, findPaths, formatPath, findContainers, getDescriptorIdsByTags, computeVisibleNodeIds } from './graph';
 import type { AlpsDocument } from '../parser/alps-parser';
 
 const DOC: AlpsDocument = {
@@ -98,5 +98,51 @@ describe('findPaths', () => {
 
   it('respects maxPaths', () => {
     expect(findPaths(graph, 'Home', 'Checkout', 1).length).toBe(1);
+  });
+});
+
+describe('getDescriptorIdsByTags', () => {
+  const doc = {
+    alps: {
+      descriptor: [
+        { id: 'Home', type: 'semantic' as const, tag: 'front nav' },
+        { id: 'Cart', type: 'semantic' as const, tag: 'cart' },
+        { id: 'goCart', type: 'safe' as const, rt: '#Cart', tag: 'cart flow-purchase' },
+        { id: 'untagged', type: 'semantic' as const },
+      ],
+    },
+  };
+
+  it('collects ids whose space-separated tags intersect the requested tags', () => {
+    expect([...getDescriptorIdsByTags(doc, ['cart'])].sort()).toEqual(['Cart', 'goCart']);
+    expect([...getDescriptorIdsByTags(doc, ['flow-purchase', 'nav'])].sort()).toEqual(['Home', 'goCart']);
+  });
+
+  it('returns an empty set for unknown tags', () => {
+    expect(getDescriptorIdsByTags(doc, ['nope']).size).toBe(0);
+  });
+});
+
+describe('computeVisibleNodeIds', () => {
+  const doc = {
+    alps: {
+      descriptor: [
+        { id: 'Home', type: 'semantic' as const, descriptor: [{ href: '#goCart' }] },
+        { id: 'Cart', type: 'semantic' as const },
+        { id: 'goCart', type: 'safe' as const, rt: '#Cart' },
+      ],
+    },
+  };
+
+  it('includes endpoints of tagged transitions even when the states are untagged', () => {
+    const graph = extractGraph(doc);
+    const visible = computeVisibleNodeIds(graph, new Set(['goCart']));
+    expect([...visible].sort()).toEqual(['Cart', 'Home']);
+  });
+
+  it('includes tagged states on their own', () => {
+    const graph = extractGraph(doc);
+    const visible = computeVisibleNodeIds(graph, new Set(['Cart']));
+    expect([...visible]).toEqual(['Cart']);
   });
 });

--- a/packages/app-state-diagram/src/graph/graph.test.ts
+++ b/packages/app-state-diagram/src/graph/graph.test.ts
@@ -45,6 +45,10 @@ describe('extractGraph', () => {
     expect(graph.states.find(s => s.id === 'price')).toBeUndefined();
   });
 
+  it('handles missing ALPS descriptors', () => {
+    expect(extractGraph({} as AlpsDocument)).toEqual({ states: [], transitions: [] });
+  });
+
   it('excludes transitions with external rt references', () => {
     const doc: AlpsDocument = {
       alps: {
@@ -124,6 +128,10 @@ describe('getDescriptorIdsByTags', () => {
 
   it('returns an empty set for unknown tags', () => {
     expect(getDescriptorIdsByTags(doc, ['nope']).size).toBe(0);
+  });
+
+  it('handles missing ALPS descriptors when collecting tags', () => {
+    expect(getDescriptorIdsByTags({} as AlpsDocument, ['cart']).size).toBe(0);
   });
 });
 

--- a/packages/app-state-diagram/src/graph/graph.test.ts
+++ b/packages/app-state-diagram/src/graph/graph.test.ts
@@ -99,6 +99,10 @@ describe('findPaths', () => {
   it('respects maxPaths', () => {
     expect(findPaths(graph, 'Home', 'Checkout', 1).length).toBe(1);
   });
+
+  it('respects maxDepth', () => {
+    expect(findPaths(graph, 'Home', 'Checkout', 10, 0)).toEqual([]);
+  });
 });
 
 describe('getDescriptorIdsByTags', () => {

--- a/packages/app-state-diagram/src/graph/graph.test.ts
+++ b/packages/app-state-diagram/src/graph/graph.test.ts
@@ -1,0 +1,102 @@
+import { extractGraph, findPaths, formatPath, findContainers } from './graph';
+import type { AlpsDocument } from '../parser/alps-parser';
+
+const DOC: AlpsDocument = {
+  alps: {
+    title: 'Store',
+    descriptor: [
+      { id: 'Home', type: 'semantic', descriptor: [{ href: '#goCatalog' }, { href: '#goCart' }] },
+      {
+        id: 'Catalog',
+        type: 'semantic',
+        descriptor: [{ href: '#goHome' }, { href: '#doAddToCart' }],
+      },
+      { id: 'Cart', type: 'semantic', descriptor: [{ href: '#goCheckout' }] },
+      { id: 'Checkout', type: 'semantic' },
+      { id: 'goCatalog', type: 'safe', rt: '#Catalog' },
+      { id: 'goCart', type: 'safe', rt: '#Cart' },
+      { id: 'goHome', type: 'safe', rt: '#Home' },
+      { id: 'doAddToCart', type: 'unsafe', rt: '#Cart' },
+      { id: 'goCheckout', type: 'safe', rt: '#Checkout' },
+      { id: 'price', type: 'semantic' },
+    ],
+  },
+};
+
+describe('extractGraph', () => {
+  const graph = extractGraph(DOC);
+
+  it('extracts states (rt targets and transition containers)', () => {
+    expect(graph.states.map(s => s.id).sort()).toEqual(['Cart', 'Catalog', 'Checkout', 'Home']);
+  });
+
+  it('extracts transitions with from/to', () => {
+    const addToCart = graph.transitions.find(t => t.id === 'doAddToCart');
+    expect(addToCart).toEqual({
+      id: 'doAddToCart',
+      type: 'unsafe',
+      title: undefined,
+      from: ['Catalog'],
+      to: 'Cart',
+    });
+  });
+
+  it('does not treat plain semantic descriptors as states', () => {
+    expect(graph.states.find(s => s.id === 'price')).toBeUndefined();
+  });
+
+  it('excludes transitions with external rt references', () => {
+    const doc: AlpsDocument = {
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', descriptor: [{ href: '#goExt' }, { href: '#goSelf' }] },
+          { id: 'goExt', type: 'safe', rt: 'other.json#Remote' },
+          { id: 'goSelf', type: 'safe', rt: '#Home' },
+        ],
+      },
+    };
+    const g = extractGraph(doc);
+    expect(g.transitions.map(t => t.id)).toEqual(['goSelf']);
+    expect(g.states.map(s => s.id)).toEqual(['Home']);
+  });
+});
+
+describe('findContainers', () => {
+  it('finds all containers of a descriptor', () => {
+    expect(findContainers('goHome', DOC.alps.descriptor!)).toEqual(['Catalog']);
+  });
+
+  it('returns an empty array when not contained', () => {
+    expect(findContainers('price', DOC.alps.descriptor!)).toEqual([]);
+  });
+});
+
+describe('findPaths', () => {
+  const graph = extractGraph(DOC);
+
+  it('enumerates all paths between two states', () => {
+    const paths = findPaths(graph, 'Home', 'Checkout');
+    const formatted = paths.map(p => formatPath('Home', p)).sort();
+    expect(formatted).toEqual([
+      'Home --goCart(safe)--> Cart --goCheckout(safe)--> Checkout',
+      'Home --goCatalog(safe)--> Catalog --doAddToCart(unsafe)--> Cart --goCheckout(safe)--> Checkout',
+    ]);
+  });
+
+  it('does not revisit states (no infinite loops on cycles)', () => {
+    const paths = findPaths(graph, 'Catalog', 'Checkout');
+    const formatted = paths.map(p => formatPath('Catalog', p)).sort();
+    expect(formatted).toEqual([
+      'Catalog --doAddToCart(unsafe)--> Cart --goCheckout(safe)--> Checkout',
+      'Catalog --goHome(safe)--> Home --goCart(safe)--> Cart --goCheckout(safe)--> Checkout',
+    ]);
+  });
+
+  it('returns an empty array when no path exists', () => {
+    expect(findPaths(graph, 'Checkout', 'Home')).toEqual([]);
+  });
+
+  it('respects maxPaths', () => {
+    expect(findPaths(graph, 'Home', 'Checkout', 1).length).toBe(1);
+  });
+});

--- a/packages/app-state-diagram/src/graph/graph.ts
+++ b/packages/app-state-diagram/src/graph/graph.ts
@@ -1,0 +1,155 @@
+/**
+ * Graph utilities for ALPS state diagrams
+ *
+ * Extracts the application state graph (states and transitions) from an
+ * ALPS document and answers reachability questions over it. Uses the same
+ * state/transition model as generator/dot-generator.ts.
+ */
+
+import { localFragment } from '../parser/alps-parser';
+import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
+
+export type TransitionType = 'safe' | 'unsafe' | 'idempotent';
+
+export interface TransitionInfo {
+  id: string;
+  type: TransitionType;
+  title?: string;
+  /** States containing this transition */
+  from: string[];
+  /** Target state (rt) */
+  to: string;
+}
+
+export interface StateGraph {
+  states: AlpsDescriptor[];
+  transitions: TransitionInfo[];
+}
+
+export interface PathStep {
+  transition: string;
+  type: TransitionType;
+  to: string;
+}
+
+const TRANSITION_TYPES = new Set(['safe', 'unsafe', 'idempotent']);
+
+/**
+ * Whether a descriptor is a state transition (safe/unsafe/idempotent with rt)
+ */
+export function isTransition(descriptor: AlpsDescriptor): boolean {
+  return !!descriptor.type && TRANSITION_TYPES.has(descriptor.type) && !!descriptor.rt;
+}
+
+/**
+ * Extract the state graph from an ALPS document
+ */
+export function extractGraph(alpsData: AlpsDocument): StateGraph {
+  const descriptors = alpsData.alps?.descriptor || [];
+
+  const transitions: TransitionInfo[] = [];
+  for (const desc of descriptors) {
+    // External rt references (e.g. "other.json#State") are not part of this graph
+    const rtTarget = localFragment(desc.rt);
+    if (desc.id && isTransition(desc) && rtTarget) {
+      transitions.push({
+        id: desc.id,
+        type: desc.type as TransitionType,
+        title: desc.title,
+        from: findContainers(desc.id, descriptors),
+        to: rtTarget,
+      });
+    }
+  }
+
+  const stateIds = new Set<string>();
+  for (const trans of transitions) {
+    stateIds.add(trans.to);
+    for (const from of trans.from) {
+      stateIds.add(from);
+    }
+  }
+  const states = descriptors.filter(d => d.id && stateIds.has(d.id));
+
+  return { states, transitions };
+}
+
+/**
+ * Find descriptors that contain the given descriptor (by href or inline id)
+ */
+export function findContainers(childId: string, descriptors: AlpsDescriptor[]): string[] {
+  const containers: string[] = [];
+  for (const desc of descriptors) {
+    if (desc.id && Array.isArray(desc.descriptor)) {
+      const contains = desc.descriptor.some(
+        nested => nested.href === `#${childId}` || nested.id === childId
+      );
+      if (contains) {
+        containers.push(desc.id);
+      }
+    }
+  }
+  return containers;
+}
+
+/**
+ * Enumerate paths between two states (DFS, no state revisited within a path)
+ */
+export function findPaths(
+  graph: StateGraph,
+  from: string,
+  to: string,
+  maxPaths = 10,
+  maxDepth = 10
+): PathStep[][] {
+  const edgesFrom = new Map<string, TransitionInfo[]>();
+  for (const trans of graph.transitions) {
+    for (const source of trans.from) {
+      if (!edgesFrom.has(source)) {
+        edgesFrom.set(source, []);
+      }
+      edgesFrom.get(source)!.push(trans);
+    }
+  }
+
+  const paths: PathStep[][] = [];
+  const visited = new Set<string>([from]);
+  const current: PathStep[] = [];
+
+  const dfs = (state: string): void => {
+    if (paths.length >= maxPaths || current.length >= maxDepth) {
+      return;
+    }
+    for (const trans of edgesFrom.get(state) || []) {
+      if (visited.has(trans.to)) {
+        continue;
+      }
+      current.push({ transition: trans.id, type: trans.type, to: trans.to });
+      if (trans.to === to) {
+        paths.push([...current]);
+      } else {
+        visited.add(trans.to);
+        dfs(trans.to);
+        visited.delete(trans.to);
+      }
+      current.pop();
+      if (paths.length >= maxPaths) {
+        return;
+      }
+    }
+  };
+
+  dfs(from);
+  return paths;
+}
+
+/**
+ * Format a path as a readable string: Home --goToCart(safe)--> ShoppingCart
+ */
+export function formatPath(from: string, path: PathStep[]): string {
+  let result = from;
+  for (const step of path) {
+    result += ` --${step.transition}(${step.type})--> ${step.to}`;
+  }
+  return result;
+}

--- a/packages/app-state-diagram/src/graph/graph.ts
+++ b/packages/app-state-diagram/src/graph/graph.ts
@@ -6,7 +6,7 @@
  * state/transition model as generator/dot-generator.ts.
  */
 
-import { localFragment } from '../parser/alps-parser';
+import { localFragment, walkDescriptors } from '../parser/alps-parser';
 import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
 
 export type TransitionType = 'safe' | 'unsafe' | 'idempotent';
@@ -152,4 +152,43 @@ export function formatPath(from: string, path: PathStep[]): string {
     result += ` --${step.transition}(${step.type})--> ${step.to}`;
   }
   return result;
+}
+
+/**
+ * Collect ids of descriptors carrying any of the given tags
+ * (space-separated tag attribute; nested descriptors included)
+ */
+export function getDescriptorIdsByTags(alpsData: AlpsDocument, tags: string[]): Set<string> {
+  const wanted = new Set(tags.filter(Boolean));
+  const ids = new Set<string>();
+  walkDescriptors(alpsData.alps?.descriptor || [], desc => {
+    if (!desc.id || !desc.tag) {
+      return;
+    }
+    if (desc.tag.split(/\s+/).some(tag => wanted.has(tag))) {
+      ids.add(desc.id);
+    }
+  });
+  return ids;
+}
+
+/**
+ * Visible node ids for a tag-filtered diagram: tagged states plus the
+ * endpoints of tagged transitions. Same semantics as the HTML viewer's
+ * "Show selected tags only" filter (induced subgraph).
+ */
+export function computeVisibleNodeIds(graph: StateGraph, filterIds: Set<string>): Set<string> {
+  const visible = new Set<string>();
+  for (const state of graph.states) {
+    if (state.id && filterIds.has(state.id)) {
+      visible.add(state.id);
+    }
+  }
+  for (const trans of graph.transitions) {
+    if (filterIds.has(trans.id)) {
+      visible.add(trans.to);
+      trans.from.forEach(source => visible.add(source));
+    }
+  }
+  return visible;
 }

--- a/packages/app-state-diagram/src/graph/index.ts
+++ b/packages/app-state-diagram/src/graph/index.ts
@@ -1,2 +1,2 @@
-export { extractGraph, findContainers, findPaths, formatPath, isTransition } from './graph';
+export { extractGraph, findContainers, findPaths, formatPath, isTransition, getDescriptorIdsByTags, computeVisibleNodeIds } from './graph';
 export type { StateGraph, TransitionInfo, TransitionType, PathStep } from './graph';

--- a/packages/app-state-diagram/src/graph/index.ts
+++ b/packages/app-state-diagram/src/graph/index.ts
@@ -1,0 +1,2 @@
+export { extractGraph, findContainers, findPaths, formatPath, isTransition } from './graph';
+export type { StateGraph, TransitionInfo, TransitionType, PathStep } from './graph';

--- a/packages/app-state-diagram/src/parser/alps-parser.test.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.test.ts
@@ -65,6 +65,27 @@ describe('parseAlpsAuto', () => {
     expect(() => parseAlps('{', 'JSON')).toThrow('Invalid JSON format');
     expect(() => parseAlps('<not-alps/>', 'XML')).toThrow('No alps element found');
   });
+
+  it('uses XML defaults for omitted descriptors and link attributes', () => {
+    const doc = parseAlps('<alps><link/></alps>', 'XML');
+
+    expect(doc.alps.title).toBe('ALPS Profile');
+    expect(doc.alps.descriptor).toEqual([]);
+    expect(doc.alps.link).toEqual([{ rel: '', href: '', title: '' }]);
+  });
+
+  it('handles sparse XML doc objects', () => {
+    const withContentType = parseAlpsAuto(
+      '<alps><descriptor id="x"><doc contentType="text/plain">hello</doc></descriptor></alps>'
+    );
+    expect(withContentType.alps.descriptor?.[0].doc).toEqual({
+      value: 'hello',
+      contentType: 'text/plain',
+    });
+
+    const emptyDoc = parseAlpsAuto('<alps><descriptor id="x"><doc unknown="ignored"/></descriptor></alps>');
+    expect(emptyDoc.alps.descriptor?.[0].doc).toBeUndefined();
+  });
 });
 
 describe('docText', () => {
@@ -113,5 +134,9 @@ describe('findDescriptorById', () => {
   it('returns null for unknown ids and non-array input', () => {
     expect(findDescriptorById(descriptors, 'nope')).toBeNull();
     expect(findDescriptorById(undefined, 'a')).toBeNull();
+  });
+
+  it('skips non-object entries while searching', () => {
+    expect(findDescriptorById([null, 'x', { id: 'a' }], 'a')).toEqual({ id: 'a' });
   });
 });

--- a/packages/app-state-diagram/src/parser/alps-parser.test.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.test.ts
@@ -1,4 +1,5 @@
 import {
+  parseAlps,
   parseAlpsAuto,
   docText,
   localFragment,
@@ -26,6 +27,43 @@ describe('parseAlpsAuto', () => {
       '<alps><descriptor id="x"><doc href="alps-doc/x.md" format="markdown"/></descriptor></alps>'
     );
     expect(doc.alps.descriptor?.[0].doc).toEqual({ href: 'alps-doc/x.md', format: 'markdown' });
+  });
+
+  it('parses XML root docs, links, and nested descriptor references', () => {
+    const doc = parseAlpsAuto(`
+      <alps>
+        <title>Store</title>
+        <doc href="README.md" format="markdown" contentType="text/markdown">Overview</doc>
+        <link rel="help" href="help.html" title="Help"/>
+        <descriptor id="Home" type="semantic" tag="page-home" def="def" rel="self" href="#Home">
+          <descriptor href="#goCart"/>
+        </descriptor>
+        <descriptor id="goCart" type="safe" rt="#Cart"/>
+      </alps>
+    `);
+
+    expect(doc.alps.title).toBe('Store');
+    expect(doc.alps.doc).toEqual({
+      value: 'Overview',
+      href: 'README.md',
+      format: 'markdown',
+      contentType: 'text/markdown',
+    });
+    expect(doc.alps.link).toEqual([{ rel: 'help', href: 'help.html', title: 'Help' }]);
+    expect(doc.alps.descriptor?.[0]).toMatchObject({
+      id: 'Home',
+      type: 'semantic',
+      tag: 'page-home',
+      def: 'def',
+      rel: 'self',
+      href: '#Home',
+      descriptor: [{ href: '#goCart' }],
+    });
+  });
+
+  it('throws readable parse errors', () => {
+    expect(() => parseAlps('{', 'JSON')).toThrow('Invalid JSON format');
+    expect(() => parseAlps('<not-alps/>', 'XML')).toThrow('No alps element found');
   });
 });
 

--- a/packages/app-state-diagram/src/parser/alps-parser.test.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.test.ts
@@ -94,6 +94,7 @@ describe('docText', () => {
     expect(docText({ value: 'v' })).toBe('v');
     expect(docText({ href: 'x.md' })).toBe('');
     expect(docText(undefined)).toBe('');
+    expect(docText(null)).toBe('');
   });
 });
 

--- a/packages/app-state-diagram/src/parser/alps-parser.test.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.test.ts
@@ -1,0 +1,79 @@
+import {
+  parseAlpsAuto,
+  docText,
+  localFragment,
+  walkDescriptors,
+  findDescriptorById,
+} from './alps-parser';
+import type { AlpsDescriptor } from './alps-parser';
+
+describe('parseAlpsAuto', () => {
+  it('parses JSON profiles', () => {
+    const doc = parseAlpsAuto('{"alps": {"title": "T", "descriptor": [{"id": "x"}]}}');
+    expect(doc.alps.title).toBe('T');
+    expect(doc.alps.descriptor?.[0].id).toBe('x');
+  });
+
+  it('parses XML doc text content', () => {
+    const doc = parseAlpsAuto(
+      '<alps><descriptor id="x"><doc>hello</doc></descriptor></alps>'
+    );
+    expect(docText(doc.alps.descriptor?.[0].doc)).toBe('hello');
+  });
+
+  it('parses XML doc href and format attributes', () => {
+    const doc = parseAlpsAuto(
+      '<alps><descriptor id="x"><doc href="alps-doc/x.md" format="markdown"/></descriptor></alps>'
+    );
+    expect(doc.alps.descriptor?.[0].doc).toEqual({ href: 'alps-doc/x.md', format: 'markdown' });
+  });
+});
+
+describe('docText', () => {
+  it('handles string, object, and undefined forms', () => {
+    expect(docText('plain')).toBe('plain');
+    expect(docText({ value: 'v' })).toBe('v');
+    expect(docText({ href: 'x.md' })).toBe('');
+    expect(docText(undefined)).toBe('');
+  });
+});
+
+describe('localFragment', () => {
+  it('extracts local fragment ids', () => {
+    expect(localFragment('#Home')).toBe('Home');
+  });
+
+  it('returns null for external and missing references', () => {
+    expect(localFragment('other.json#Home')).toBeNull();
+    expect(localFragment('http://example.com/alps#Home')).toBeNull();
+    expect(localFragment(undefined)).toBeNull();
+  });
+});
+
+describe('walkDescriptors', () => {
+  it('visits nested descriptors depth-first', () => {
+    const descriptors: AlpsDescriptor[] = [
+      { id: 'a', descriptor: [{ id: 'b', descriptor: [{ id: 'c' }] }] },
+      { id: 'd' },
+    ];
+    const visited: (string | undefined)[] = [];
+    walkDescriptors(descriptors, desc => visited.push(desc.id));
+    expect(visited).toEqual(['a', 'b', 'c', 'd']);
+  });
+});
+
+describe('findDescriptorById', () => {
+  const descriptors = [
+    { id: 'a', descriptor: [{ id: 'b' }] },
+    { id: 'c' },
+  ];
+
+  it('finds nested descriptors', () => {
+    expect(findDescriptorById(descriptors, 'b')).toEqual({ id: 'b' });
+  });
+
+  it('returns null for unknown ids and non-array input', () => {
+    expect(findDescriptorById(descriptors, 'nope')).toBeNull();
+    expect(findDescriptorById(undefined, 'a')).toBeNull();
+  });
+});

--- a/packages/app-state-diagram/src/parser/alps-parser.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.ts
@@ -89,6 +89,8 @@ function parseAlpsXml(content: string): AlpsDocument {
 
     const parsed = parser.parse(content);
     return xmlToAlpsObject(parsed);
+  /* c8 ignore next 3 -- fast-xml-parser is intentionally tolerant, but keep a readable wrapper for parser failures. */
+  /* istanbul ignore next -- see c8 ignore above */
   } catch (e) {
     throw new Error(`Invalid XML format: ${(e as Error).message}`);
   }

--- a/packages/app-state-diagram/src/parser/alps-parser.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.ts
@@ -24,6 +24,7 @@ export interface AlpsDescriptor {
   rt?: string;
   tag?: string;
   href?: string;
+  link?: AlpsLink | AlpsLink[];
   descriptor?: AlpsDescriptor[];
 }
 

--- a/packages/app-state-diagram/src/parser/alps-parser.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.ts
@@ -172,8 +172,8 @@ function convertDoc(doc: any): string | AlpsDoc | undefined {
 /**
  * Get the inline text of a doc (string or AlpsDoc form)
  */
-export function docText(doc: string | AlpsDoc | undefined): string {
-  if (doc === undefined) {
+export function docText(doc: string | AlpsDoc | null | undefined): string {
+  if (doc == null) {
     return '';
   }
   if (typeof doc === 'string') {

--- a/packages/app-state-diagram/src/parser/alps-parser.ts
+++ b/packages/app-state-diagram/src/parser/alps-parser.ts
@@ -7,12 +7,19 @@
 
 import { XMLParser } from 'fast-xml-parser';
 
+export interface AlpsDoc {
+  value?: string;
+  href?: string;
+  format?: string;
+  contentType?: string;
+}
+
 export interface AlpsDescriptor {
   id?: string;
   type?: 'semantic' | 'safe' | 'unsafe' | 'idempotent';
   title?: string;
   def?: string;
-  doc?: string | { value: string };
+  doc?: string | AlpsDoc;
   rel?: string;
   rt?: string;
   tag?: string;
@@ -29,7 +36,7 @@ export interface AlpsLink {
 export interface AlpsDocument {
   alps: {
     title?: string;
-    doc?: string | { value: string };
+    doc?: string | AlpsDoc;
     descriptor?: AlpsDescriptor[];
     link?: AlpsLink | AlpsLink[];
   };
@@ -116,16 +123,108 @@ function xmlToAlpsObject(parsed: any): AlpsDocument {
   const result: AlpsDocument = {
     alps: {
       title: alps.title?.['#text'] || alps.title || 'ALPS Profile',
-      doc: alps.doc?.['#text'] || alps.doc || '',
       descriptor: descriptors,
     },
   };
+
+  const rootDoc = convertDoc(alps.doc);
+  if (rootDoc !== undefined) {
+    result.alps.doc = rootDoc;
+  }
 
   if (links.length > 0) {
     result.alps.link = links;
   }
 
   return result;
+}
+
+/**
+ * Convert XML doc element to string or AlpsDoc.
+ * Supports <doc>text</doc> and <doc href="..." format="..."/> forms.
+ */
+function convertDoc(doc: any): string | AlpsDoc | undefined {
+  if (doc === undefined || doc === null) {
+    return undefined;
+  }
+  if (typeof doc === 'string') {
+    return doc;
+  }
+  const result: AlpsDoc = {};
+  if (doc['#text'] !== undefined) {
+    result.value = String(doc['#text']);
+  }
+  if (doc['@_href']) {
+    result.href = doc['@_href'];
+  }
+  if (doc['@_format']) {
+    result.format = doc['@_format'];
+  }
+  if (doc['@_contentType']) {
+    result.contentType = doc['@_contentType'];
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Get the inline text of a doc (string or AlpsDoc form)
+ */
+export function docText(doc: string | AlpsDoc | undefined): string {
+  if (doc === undefined) {
+    return '';
+  }
+  if (typeof doc === 'string') {
+    return doc;
+  }
+  return doc.value || '';
+}
+
+/**
+ * Extract a local fragment id from an href/rt reference.
+ * Returns null for external references ("file.json#id", "http://...").
+ */
+export function localFragment(ref: string | undefined): string | null {
+  if (!ref || !ref.startsWith('#')) {
+    return null;
+  }
+  return ref.substring(1);
+}
+
+/**
+ * Visit every descriptor in a tree, depth-first
+ */
+export function walkDescriptors(
+  descriptors: AlpsDescriptor[],
+  visit: (desc: AlpsDescriptor) => void
+): void {
+  for (const desc of descriptors) {
+    visit(desc);
+    if (Array.isArray(desc.descriptor)) {
+      walkDescriptors(desc.descriptor, visit);
+    }
+  }
+}
+
+/**
+ * Find a descriptor by id, searching nested descriptors.
+ * Accepts unknown input so it can be used on raw (unnormalized) JSON.
+ */
+export function findDescriptorById(descriptors: unknown, id: string): AlpsDescriptor | null {
+  if (!Array.isArray(descriptors)) {
+    return null;
+  }
+  for (const desc of descriptors) {
+    if (desc && typeof desc === 'object') {
+      if ((desc as AlpsDescriptor).id === id) {
+        return desc as AlpsDescriptor;
+      }
+      const found = findDescriptorById((desc as AlpsDescriptor).descriptor, id);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -144,8 +243,9 @@ function convertDescriptor(desc: any): AlpsDescriptor {
   };
 
   // Extract doc element
-  if (desc.doc) {
-    descriptor.doc = desc.doc['#text'] || desc.doc;
+  const doc = convertDoc(desc.doc);
+  if (doc !== undefined) {
+    descriptor.doc = doc;
   }
 
   // Extract nested descriptors

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -73,6 +73,12 @@ Validate an ALPS profile and get detailed error feedback.
 
 ### alps2svg
 
+**Parameters:**
+- `alps_content` or `alps_path` (required)
+- `tag` (optional): Filter to the tagged slice — space/comma separated tags; shows the induced subgraph (tagged nodes plus endpoints of tagged transitions)
+- `output` (optional): Write the SVG to this file path and return the path (recommended for large diagrams)
+
+
 Generate an SVG state diagram from an ALPS profile.
 
 **Parameters:**
@@ -81,6 +87,17 @@ Generate an SVG state diagram from an ALPS profile.
 
 **Example prompt:**
 > "Generate a state diagram from my ALPS profile at ./api.json"
+
+### alps2mermaid
+
+Convert ALPS profile to Mermaid classDiagram (renders natively in GitHub, claude.ai artifacts, VS Code).
+
+**Parameters:**
+- `alps_content` or `alps_path` (required)
+- `tag` (optional): Filter to the tagged slice (same semantics as alps2svg)
+
+**Example prompt:**
+> "Show me the checkout flow of profile.json as a diagram"
 
 ### alps_guide
 
@@ -108,11 +125,12 @@ Filter descriptors by type, tag, and/or free text (matched against id, title, an
 **Parameters:**
 - `file` (required): Path to the ALPS profile file
 - `type` (optional): `semantic` | `safe` | `unsafe` | `idempotent`
-- `tag` (optional): Filter by tag
+- `tag` (optional): Filter by tag(s), space or comma separated (OR match)
 - `text` (optional): Case-insensitive text search
+- `format` (optional): `json` (default) or `markdown` — a table (ID, Type, Title, Tags, Doc) for direct display in chat
 
 **Example prompt:**
-> "List all unsafe transitions tagged checkout in profile.json"
+> "List all unsafe transitions tagged checkout in profile.json as a table"
 
 ### alps_descriptor
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -91,6 +91,86 @@ Get ALPS best practices and reference guide.
 **Example prompt:**
 > "Show me ALPS best practices for naming transitions"
 
+### alps_overview
+
+Summarize an ALPS profile: title, application states, transitions (with from/to states), and tags. Use this first to understand the application state model.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file (JSON or XML)
+
+**Example prompt:**
+> "Give me an overview of profile.json"
+
+### alps_search
+
+Filter descriptors by type, tag, and/or free text (matched against id, title, and doc). Searches nested descriptors too. Returns compact summaries.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file
+- `type` (optional): `semantic` | `safe` | `unsafe` | `idempotent`
+- `tag` (optional): Filter by tag
+- `text` (optional): Case-insensitive text search
+
+**Example prompt:**
+> "List all unsafe transitions tagged checkout in profile.json"
+
+### alps_descriptor
+
+Get full details of one descriptor: definition, resolved documentation (external doc files are read and inlined), containing states, and incoming/outgoing transitions.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file
+- `id` (required): Descriptor id
+
+**Example prompt:**
+> "Show me everything about the Cart descriptor"
+
+### alps_paths
+
+Enumerate transition paths from one application state to another.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file
+- `from` (required): Starting state id
+- `to` (required): Target state id
+- `maxPaths` (optional): Maximum paths (default 10)
+
+**Example prompt:**
+> "How does a user get from Home to OrderConfirmation?"
+
+### alps_set_doc
+
+Set or update the documentation of a descriptor in a JSON ALPS profile. Short single-line docs are stored inline; longer or multi-line docs (Markdown welcome) are automatically written to an external file and linked via `doc.href`.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file (JSON only for writes)
+- `id` (required): Descriptor id
+- `doc` (required): Documentation text
+- `placement` (optional): `auto` (default) | `inline` | `external`
+
+**Example prompt:**
+> "Document the ShoppingCart state with the business rules we discussed"
+
+## Auxiliary Design Information (alps/)
+
+`alps_set_doc` keeps profiles compact: docs over 200 characters or with multiple lines are written to `alps/docs/<descriptor-id>.md` next to the profile and linked via the ALPS `doc` element's `href`:
+
+```json
+"doc": { "href": "alps/docs/ShoppingCart.md", "format": "markdown" }
+```
+
+The `alps/` directory is the home for all auxiliary design information:
+
+```text
+profile.json
+alps/
+├── docs/    # per-descriptor rich documentation (doc.href targets)
+├── rels/    # link relation definitions (reserved)
+└── links/   # compacted summaries of external link targets (reserved)
+```
+
+Existing local `doc.href` layouts keep working: any safe local href is honored and updated in place. Reading tools resolve these links and inline the file content automatically. Paths escaping the profile directory (absolute, `../`, escaping symlinks) are rejected.
+
 ## Example Workflow
 
 1. Ask the AI to validate your ALPS profile:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -76,7 +76,7 @@ Validate an ALPS profile and get detailed error feedback.
 
 **Parameters:**
 - `alps_content` or `alps_path` (required)
-- `tag` (optional): Filter to the tagged slice — space/comma separated tags; shows the induced subgraph (tagged nodes plus endpoints of tagged transitions)
+- `tag` (optional): Filter to the tagged slice — space/comma-separated tags; shows the induced subgraph (tagged nodes plus endpoints of tagged transitions)
 - `output` (optional): Write the SVG to this file path and return the path (recommended for large diagrams)
 
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -197,6 +197,18 @@ Add and/or remove tags in a descriptor's space-separated `tag` attribute. Kept t
 **Example prompt:**
 > "Tag the Cart and Checkout states with checkout"
 
+### alps_rename
+
+Rename a descriptor and update all local references across the profile: `href` and `rt` `#fragments` at any nesting depth. Only exact-id matches are rewritten; external references (`file.json#id`) are left untouched. An external doc file (`doc.href`) keeps its old file name — the result reports it as `docFile`; it stays linked and keeps working since the href still points at it.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file (JSON only for writes)
+- `id` (required): Current descriptor id
+- `newId` (required): New descriptor id
+
+**Example prompt:**
+> "Rename Cart to ShoppingCart everywhere"
+
 ## Auxiliary Design Information (alps/)
 
 `alps_set_doc` keeps profiles compact: docs over 200 characters or with multiple lines are written to `alps/docs/<descriptor-id>.md` next to the profile and linked via the ALPS `doc` element's `href`:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -62,6 +62,7 @@ Validate an ALPS profile and get detailed error feedback.
 
 **Parameters:**
 - `alps_content` (required): ALPS profile content (XML or JSON format)
+- `vocabulary` (optional): Path to a tag vocabulary file (`tags.html` defining each tag as a `<dt>` id — see [ALPS Tag Vocabulary](../../docs/tag-vocabulary.md)). Tags used in the profile but not defined there are reported as `W005` warnings, and tags defined but never used are listed informationally — so typos surface instead of silently creating new categories.
 
 **Example prompt:**
 > "Validate this ALPS profile and tell me if there are any errors"
@@ -257,6 +258,7 @@ Existing local `doc.href` layouts keep working: any safe local href is honored a
 | W001 | Warning | Missing title |
 | W002 | Warning | Safe transition should start with "go" |
 | W003 | Warning | Unsafe/idempotent should start with "do" |
+| W005 | Warning | Tag not defined in the vocabulary file |
 | S001 | Suggestion | Consider adding doc to transition |
 
 See [Validation Reference](../../dev-docs/validation-reference.md) for detailed explanations.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -133,6 +133,18 @@ Filter descriptors by type, tag, and/or free text (matched against id, title, an
 **Example prompt:**
 > "List all unsafe transitions tagged checkout in profile.json as a table"
 
+### alps_tags
+
+List the tags in use across a profile, grouped by facet (`actor-`, `flow-`, `feature-`, `src-`, `page-` prefixes; everything else is domain vocabulary) with usage counts. Given a `vocabulary` file ([ALPS Tag Vocabulary](../../docs/tag-vocabulary.md)), each tag is joined with its definition: `defined` and the `<dt>` title.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file
+- `vocabulary` (optional): Path to a tag vocabulary file (`tags.html` defining each tag as a `<dt>` id)
+- `format` (optional): `json` (default) or `markdown` — a table (Tag, Facet, Count, Defined, Title) for direct display in chat
+
+**Example prompt:**
+> "Which tags does profile.json use, and are they all in the vocabulary?"
+
 ### alps_descriptor
 
 Get full details of one descriptor: definition, resolved documentation (external doc files are read and inlined), containing states, and incoming/outgoing transitions. `rel="describedby"` links are returned as `describedBy`; local files inside the profile directory are read and inlined as `text`, while http(s) links are returned unresolved.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -184,6 +184,19 @@ Add a new descriptor to a JSON ALPS profile. Containers reference children via `
 **Example prompt:**
 > "Register name and age as person"
 
+### alps_set_tags
+
+Add and/or remove tags in a descriptor's space-separated `tag` attribute. Kept tags preserve their order, new tags are appended, and the `tag` property is removed when it becomes empty.
+
+**Parameters:**
+- `file` (required): Path to the ALPS profile file (JSON only for writes)
+- `id` (required): Descriptor id
+- `add` (optional): Tags to add (ones already present are ignored)
+- `remove` (optional): Tags to remove (at least one of `add`/`remove` is required)
+
+**Example prompt:**
+> "Tag the Cart and Checkout states with checkout"
+
 ## Auxiliary Design Information (alps/)
 
 `alps_set_doc` keeps profiles compact: docs over 200 characters or with multiple lines are written to `alps/docs/<descriptor-id>.md` next to the profile and linked via the ALPS `doc` element's `href`:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -169,6 +169,21 @@ Set or update the documentation of a descriptor in a JSON ALPS profile. Short si
 **Example prompt:**
 > "Document the ShoppingCart state with the business rules we discussed"
 
+### alps_add_descriptor
+
+Add a new descriptor to a JSON ALPS profile. Containers reference children via `href` fragments (ALPS best practice); missing children are created as top-level semantic descriptors.
+
+**Parameters:**
+- `file` (required), `id` (required)
+- `type` (optional): `semantic` (default) | `safe` | `unsafe` | `idempotent`
+- `title`, `doc`, `tag` (optional) — long docs auto-externalize to `alps/docs/<id>.md`
+- `rt` (optional): transition target; bare ids are normalized to `#fragments`
+- `children` (optional): child ids referenced as `href` fragments
+- `parent` (optional): nest inside an existing descriptor
+
+**Example prompt:**
+> "Register name and age as person"
+
 ## Auxiliary Design Information (alps/)
 
 `alps_set_doc` keeps profiles compact: docs over 200 characters or with multiple lines are written to `alps/docs/<descriptor-id>.md` next to the profile and linked via the ALPS `doc` element's `href`:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -134,7 +134,7 @@ Filter descriptors by type, tag, and/or free text (matched against id, title, an
 
 ### alps_descriptor
 
-Get full details of one descriptor: definition, resolved documentation (external doc files are read and inlined), containing states, and incoming/outgoing transitions.
+Get full details of one descriptor: definition, resolved documentation (external doc files are read and inlined), containing states, and incoming/outgoing transitions. `rel="describedby"` links are returned as `describedBy`; local files inside the profile directory are read and inlined as `text`, while http(s) links are returned unresolved.
 
 **Parameters:**
 - `file` (required): Path to the ALPS profile file

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -126,7 +126,7 @@ Filter descriptors by type, tag, and/or free text (matched against id, title, an
 **Parameters:**
 - `file` (required): Path to the ALPS profile file
 - `type` (optional): `semantic` | `safe` | `unsafe` | `idempotent`
-- `tag` (optional): Filter by tag(s), space or comma separated (OR match)
+- `tag` (optional): Filter by tag(s), space- or comma-separated (OR match)
 - `text` (optional): Case-insensitive text search
 - `format` (optional): `json` (default) or `markdown` — a table (ID, Type, Title, Tags, Doc) for direct display in chat
 

--- a/packages/mcp/jest.config.cjs
+++ b/packages/mcp/jest.config.cjs
@@ -8,7 +8,8 @@ module.exports = {
   coverageReporters: ['text', 'lcov'],
   forceExit: true,
   moduleNameMapper: {
-    '^@alps-asd/app-state-diagram/(.*)$': '<rootDir>/../app-state-diagram/dist/$1'
+    '^@alps-asd/app-state-diagram/(.*)$': '<rootDir>/../app-state-diagram/dist/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   globals: {
     'ts-jest': {

--- a/packages/mcp/jest.config.cjs
+++ b/packages/mcp/jest.config.cjs
@@ -1,6 +1,5 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/*.test.ts'],
@@ -11,11 +10,7 @@ module.exports = {
     '^@alps-asd/app-state-diagram/(.*)$': '<rootDir>/../app-state-diagram/dist/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
-  globals: {
-    'ts-jest': {
-      tsconfig: {
-        module: 'commonjs',
-      },
-    },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: { module: 'commonjs', esModuleInterop: true } }],
   },
 };

--- a/packages/mcp/jest.config.cjs
+++ b/packages/mcp/jest.config.cjs
@@ -5,6 +5,7 @@ module.exports = {
   testMatch: ['**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js'],
   coverageReporters: ['text', 'lcov'],
+  coverageProvider: 'v8',
   forceExit: true,
   moduleNameMapper: {
     '^@alps-asd/app-state-diagram/(.*)$': '<rootDir>/../app-state-diagram/dist/$1',

--- a/packages/mcp/src/descriptor-store.test.ts
+++ b/packages/mcp/src/descriptor-store.test.ts
@@ -59,6 +59,12 @@ describe("addDescriptor", () => {
     expect(home.descriptor).toEqual([{ id: "greeting" }]);
   });
 
+  it("rejects empty or whitespace ids", () => {
+    expect(() => addDescriptor(profilePath, { id: "" })).toThrow("non-empty");
+    expect(() => addDescriptor(profilePath, { id: "   " })).toThrow("non-empty");
+    expect(() => addDescriptor(profilePath, { id: "ok", children: ["", "x"] })).toThrow("non-empty");
+  });
+
   it("rejects duplicate ids", () => {
     expect(() => addDescriptor(profilePath, { id: "Home" })).toThrow("already exists");
   });

--- a/packages/mcp/src/descriptor-store.test.ts
+++ b/packages/mcp/src/descriptor-store.test.ts
@@ -82,6 +82,38 @@ describe("addDescriptor", () => {
     expect(content).toContain('\n  "alps"');
     expect(content.endsWith("\n")).toBe(true);
   });
+
+  it("rejects missing files, invalid JSON, and missing alps roots", () => {
+    expect(() => addDescriptor(path.join(dir, "missing.json"), { id: "x" })).toThrow(
+      "Profile file not found"
+    );
+
+    fs.writeFileSync(profilePath, "{");
+    expect(() => addDescriptor(profilePath, { id: "x" })).toThrow("Invalid JSON format");
+
+    fs.writeFileSync(profilePath, JSON.stringify({ notAlps: {} }));
+    expect(() => addDescriptor(profilePath, { id: "x" })).toThrow("Missing alps property");
+  });
+
+  it("initializes a missing descriptor array and preserves optional fields", () => {
+    fs.writeFileSync(profilePath, JSON.stringify({ alps: {} }, null, 2) + "\n");
+
+    const result = addDescriptor(profilePath, {
+      id: "profile",
+      type: "semantic",
+      title: "Profile",
+      tag: "core",
+      rt: "https://example.com/alps#Profile",
+    });
+
+    expect(result).toEqual({ id: "profile", createdChildren: [], warnings: [] });
+    expect(read().alps.descriptor[0]).toEqual({
+      id: "profile",
+      title: "Profile",
+      tag: "core",
+      rt: "https://example.com/alps#Profile",
+    });
+  });
 });
 
 describe("setDescriptorTags", () => {
@@ -145,6 +177,17 @@ describe("setDescriptorTags", () => {
     const content = fs.readFileSync(profilePath, "utf-8");
     expect(content).toContain('\n  "alps"');
     expect(content.endsWith("\n")).toBe(true);
+  });
+
+  it("rejects missing files and invalid JSON", () => {
+    expect(() => setDescriptorTags(path.join(dir, "missing.json"), { id: "Home", add: ["x"] })).toThrow(
+      "Profile file not found"
+    );
+
+    fs.writeFileSync(profilePath, "{");
+    expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["x"] })).toThrow(
+      "Invalid JSON format"
+    );
   });
 });
 
@@ -218,5 +261,15 @@ describe("renameDescriptor", () => {
     const content = fs.readFileSync(profilePath, "utf-8");
     expect(content).toContain('\n  "alps"');
     expect(content.endsWith("\n")).toBe(true);
+  });
+
+  it("rejects empty new ids, missing files, and invalid JSON", () => {
+    expect(() => renameDescriptor(profilePath, "Cart", "")).toThrow("non-empty");
+    expect(() => renameDescriptor(path.join(dir, "missing.json"), "Cart", "Basket")).toThrow(
+      "Profile file not found"
+    );
+
+    fs.writeFileSync(profilePath, "{");
+    expect(() => renameDescriptor(profilePath, "Cart", "Basket")).toThrow("Invalid JSON format");
   });
 });

--- a/packages/mcp/src/descriptor-store.test.ts
+++ b/packages/mcp/src/descriptor-store.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { addDescriptor, setDescriptorTags } from "./descriptor-store.js";
+import { addDescriptor, setDescriptorTags, renameDescriptor } from "./descriptor-store.js";
 
 let dir: string;
 let profilePath: string;
@@ -136,6 +136,79 @@ describe("setDescriptorTags", () => {
 
   it("preserves indentation", () => {
     setDescriptorTags(profilePath, { id: "Home", add: ["nav"] });
+    const content = fs.readFileSync(profilePath, "utf-8");
+    expect(content).toContain('\n  "alps"');
+    expect(content.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("renameDescriptor", () => {
+  beforeEach(() => {
+    fs.writeFileSync(
+      profilePath,
+      JSON.stringify(
+        {
+          alps: {
+            descriptor: [
+              {
+                id: "Home",
+                descriptor: [
+                  { href: "#goCart" },
+                  { id: "section", descriptor: [{ href: "#Cart" }] },
+                ],
+              },
+              { id: "Cart", doc: { href: "alps/docs/Cart.md", format: "markdown" } },
+              { id: "goCart", type: "safe", rt: "#Cart" },
+              { id: "shared", href: "shared.json#Cart" },
+            ],
+          },
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  });
+
+  it("renames the id and updates nested href and rt references", () => {
+    const result = renameDescriptor(profilePath, "Cart", "Basket");
+    expect(result).toEqual({
+      id: "Basket",
+      previousId: "Cart",
+      referencesUpdated: 2,
+      docFile: "alps/docs/Cart.md",
+    });
+    const profile = read();
+    expect(profile.alps.descriptor[1].id).toBe("Basket");
+    expect(profile.alps.descriptor[0].descriptor[1].descriptor[0].href).toBe("#Basket");
+    expect(profile.alps.descriptor[2].rt).toBe("#Basket");
+    // Only exact-id matches are rewritten; #goCart is not a #Cart reference
+    expect(profile.alps.descriptor[0].descriptor[0].href).toBe("#goCart");
+    // The doc file keeps its old name and stays linked via doc.href
+    expect(profile.alps.descriptor[1].doc).toEqual({ href: "alps/docs/Cart.md", format: "markdown" });
+  });
+
+  it("leaves external references untouched", () => {
+    renameDescriptor(profilePath, "Cart", "Basket");
+    expect(read().alps.descriptor[3].href).toBe("shared.json#Cart");
+  });
+
+  it("rejects collisions and unknown ids", () => {
+    expect(() => renameDescriptor(profilePath, "Cart", "Home")).toThrow(
+      "Descriptor already exists: Home"
+    );
+    expect(() => renameDescriptor(profilePath, "Nope", "Whatever")).toThrow(
+      "Descriptor not found: Nope"
+    );
+  });
+
+  it("rejects XML profiles", () => {
+    const xml = path.join(dir, "p.xml");
+    fs.writeFileSync(xml, "<alps/>");
+    expect(() => renameDescriptor(xml, "Cart", "Basket")).toThrow("JSON profiles only");
+  });
+
+  it("preserves indentation", () => {
+    renameDescriptor(profilePath, "Cart", "Basket");
     const content = fs.readFileSync(profilePath, "utf-8");
     expect(content).toContain('\n  "alps"');
     expect(content.endsWith("\n")).toBe(true);

--- a/packages/mcp/src/descriptor-store.test.ts
+++ b/packages/mcp/src/descriptor-store.test.ts
@@ -272,4 +272,12 @@ describe("renameDescriptor", () => {
     fs.writeFileSync(profilePath, "{");
     expect(() => renameDescriptor(profilePath, "Cart", "Basket")).toThrow("Invalid JSON format");
   });
+
+  it("reports not found when the descriptor array is missing", () => {
+    fs.writeFileSync(profilePath, JSON.stringify({ alps: {} }));
+
+    expect(() => renameDescriptor(profilePath, "Cart", "Basket")).toThrow(
+      "Descriptor not found: Cart"
+    );
+  });
 });

--- a/packages/mcp/src/descriptor-store.test.ts
+++ b/packages/mcp/src/descriptor-store.test.ts
@@ -1,0 +1,79 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { addDescriptor } from "./descriptor-store.js";
+
+let dir: string;
+let profilePath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "descriptor-store-"));
+  profilePath = path.join(dir, "profile.json");
+  fs.writeFileSync(
+    profilePath,
+    JSON.stringify({ alps: { descriptor: [{ id: "Home", type: "semantic" }] } }, null, 2) + "\n"
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const read = () => JSON.parse(fs.readFileSync(profilePath, "utf-8"));
+
+describe("addDescriptor", () => {
+  it("creates a container with href children, creating missing leaves", () => {
+    const result = addDescriptor(profilePath, {
+      id: "person",
+      title: "Person",
+      children: ["name", "age"],
+    });
+    expect(result.createdChildren).toEqual(["name", "age"]);
+    const profile = read();
+    const person = profile.alps.descriptor.find((d: { id?: string }) => d.id === "person");
+    expect(person).toEqual({
+      id: "person",
+      title: "Person",
+      descriptor: [{ href: "#name" }, { href: "#age" }],
+    });
+    expect(profile.alps.descriptor.map((d: { id?: string }) => d.id)).toContain("name");
+    expect(profile.alps.descriptor.map((d: { id?: string }) => d.id)).toContain("age");
+  });
+
+  it("does not recreate existing children", () => {
+    const result = addDescriptor(profilePath, { id: "Page", children: ["Home"] });
+    expect(result.createdChildren).toEqual([]);
+    expect(read().alps.descriptor.filter((d: { id?: string }) => d.id === "Home")).toHaveLength(1);
+  });
+
+  it("creates transitions with normalized rt and warns on missing targets", () => {
+    const result = addDescriptor(profilePath, { id: "goCart", type: "safe", rt: "Cart" });
+    expect(result.warnings).toEqual(['rt target "#Cart" does not exist yet']);
+    const goCart = read().alps.descriptor.find((d: { id?: string }) => d.id === "goCart");
+    expect(goCart).toEqual({ id: "goCart", type: "safe", rt: "#Cart" });
+  });
+
+  it("nests inside an existing parent", () => {
+    addDescriptor(profilePath, { id: "greeting", parent: "Home" });
+    const home = read().alps.descriptor.find((d: { id?: string }) => d.id === "Home");
+    expect(home.descriptor).toEqual([{ id: "greeting" }]);
+  });
+
+  it("rejects duplicate ids", () => {
+    expect(() => addDescriptor(profilePath, { id: "Home" })).toThrow("already exists");
+  });
+
+  it("rejects unknown parents and XML profiles", () => {
+    expect(() => addDescriptor(profilePath, { id: "x", parent: "nope" })).toThrow("Parent descriptor not found");
+    const xml = path.join(dir, "p.xml");
+    fs.writeFileSync(xml, "<alps/>");
+    expect(() => addDescriptor(xml, { id: "x" })).toThrow("JSON profiles only");
+  });
+
+  it("preserves indentation", () => {
+    addDescriptor(profilePath, { id: "person", children: ["name"] });
+    const content = fs.readFileSync(profilePath, "utf-8");
+    expect(content).toContain('\n  "alps"');
+    expect(content.endsWith("\n")).toBe(true);
+  });
+});

--- a/packages/mcp/src/descriptor-store.test.ts
+++ b/packages/mcp/src/descriptor-store.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { addDescriptor } from "./descriptor-store.js";
+import { addDescriptor, setDescriptorTags } from "./descriptor-store.js";
 
 let dir: string;
 let profilePath: string;
@@ -72,6 +72,70 @@ describe("addDescriptor", () => {
 
   it("preserves indentation", () => {
     addDescriptor(profilePath, { id: "person", children: ["name"] });
+    const content = fs.readFileSync(profilePath, "utf-8");
+    expect(content).toContain('\n  "alps"');
+    expect(content.endsWith("\n")).toBe(true);
+  });
+});
+
+describe("setDescriptorTags", () => {
+  const writeTagged = (tag: string) =>
+    fs.writeFileSync(
+      profilePath,
+      JSON.stringify({ alps: { descriptor: [{ id: "Home", tag }] } }, null, 2) + "\n"
+    );
+
+  it("adds tags to a descriptor without tags", () => {
+    const result = setDescriptorTags(profilePath, { id: "Home", add: ["nav", "core"] });
+    expect(result).toEqual({ id: "Home", tags: ["nav", "core"], added: ["nav", "core"], removed: [] });
+    expect(read().alps.descriptor[0].tag).toBe("nav core");
+  });
+
+  it("removes tags, preserving the order of kept tags", () => {
+    writeTagged("nav core checkout");
+    const result = setDescriptorTags(profilePath, { id: "Home", remove: ["core", "nope"] });
+    expect(result).toEqual({ id: "Home", tags: ["nav", "checkout"], added: [], removed: ["core"] });
+    expect(read().alps.descriptor[0].tag).toBe("nav checkout");
+  });
+
+  it("adds and removes in one call", () => {
+    writeTagged("nav old");
+    const result = setDescriptorTags(profilePath, { id: "Home", add: ["new"], remove: ["old"] });
+    expect(result).toEqual({ id: "Home", tags: ["nav", "new"], added: ["new"], removed: ["old"] });
+    expect(read().alps.descriptor[0].tag).toBe("nav new");
+  });
+
+  it("dedupes existing and added tags", () => {
+    writeTagged("nav nav");
+    const result = setDescriptorTags(profilePath, { id: "Home", add: ["nav", "core", "core"] });
+    expect(result).toEqual({ id: "Home", tags: ["nav", "core"], added: ["core"], removed: [] });
+    expect(read().alps.descriptor[0].tag).toBe("nav core");
+  });
+
+  it("deletes the tag property when it becomes empty", () => {
+    writeTagged("nav");
+    const result = setDescriptorTags(profilePath, { id: "Home", remove: ["nav"] });
+    expect(result).toEqual({ id: "Home", tags: [], added: [], removed: ["nav"] });
+    expect("tag" in read().alps.descriptor[0]).toBe(false);
+  });
+
+  it("requires add or remove", () => {
+    expect(() => setDescriptorTags(profilePath, { id: "Home" })).toThrow(
+      "At least one of add or remove is required"
+    );
+  });
+
+  it("rejects unknown ids and XML profiles", () => {
+    expect(() => setDescriptorTags(profilePath, { id: "nope", add: ["x"] })).toThrow(
+      "Descriptor not found"
+    );
+    const xml = path.join(dir, "p.xml");
+    fs.writeFileSync(xml, "<alps/>");
+    expect(() => setDescriptorTags(xml, { id: "Home", add: ["x"] })).toThrow("JSON profiles only");
+  });
+
+  it("preserves indentation", () => {
+    setDescriptorTags(profilePath, { id: "Home", add: ["nav"] });
     const content = fs.readFileSync(profilePath, "utf-8");
     expect(content).toContain('\n  "alps"');
     expect(content.endsWith("\n")).toBe(true);

--- a/packages/mcp/src/descriptor-store.ts
+++ b/packages/mcp/src/descriptor-store.ts
@@ -10,7 +10,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import { findDescriptorById } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+import { findDescriptorById, walkDescriptors } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
 import type { AlpsDescriptor } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
 import { serializeLike } from "./doc-store.js";
 
@@ -50,6 +50,16 @@ export interface SetTagsResult {
   added: string[];
   /** Tags actually removed (present before the edit) */
   removed: string[];
+}
+
+export interface RenameResult {
+  /** The new descriptor id */
+  id: string;
+  previousId: string;
+  /** Local #fragment references (href and rt) updated to the new id */
+  referencesUpdated: number;
+  /** External doc file (doc.href) kept at its old path; it stays linked and keeps working */
+  docFile?: string;
 }
 
 /**
@@ -188,4 +198,61 @@ export function setDescriptorTags(profilePath: string, input: SetTagsInput): Set
   }
   fs.writeFileSync(absPath, serializeLike(root, content), "utf-8");
   return { id: input.id, tags, added, removed };
+}
+
+/**
+ * Rename a descriptor and update all local references across the profile:
+ * href and rt "#oldId" fragments (at any nesting depth) become "#newId".
+ * Only exact-id matches are rewritten; external references
+ * ("file.json#oldId") are left untouched. An external doc file (doc.href)
+ * keeps its old file name; the result reports it as a hint since the href
+ * still points at it and keeps working.
+ */
+export function renameDescriptor(profilePath: string, oldId: string, newId: string): RenameResult {
+  const absPath = path.resolve(profilePath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Profile file not found: ${profilePath}`);
+  }
+  const content = fs.readFileSync(absPath, "utf-8");
+  if (!content.trim().startsWith("{")) {
+    throw new Error(
+      "Renaming descriptors is currently supported for JSON profiles only. " +
+        "Convert the XML profile to JSON, or edit the XML directly."
+    );
+  }
+
+  let root: { alps?: { descriptor?: unknown } };
+  try {
+    root = JSON.parse(content);
+  } catch (e) {
+    throw new Error(`Invalid JSON format: ${(e as Error).message}`);
+  }
+  const descriptors = (root.alps?.descriptor ?? []) as AlpsDescriptor[];
+  const target = findDescriptorById(descriptors, oldId);
+  if (!target) {
+    throw new Error(`Descriptor not found: ${oldId}`);
+  }
+  if (findDescriptorById(descriptors, newId)) {
+    throw new Error(`Descriptor already exists: ${newId}`);
+  }
+
+  target.id = newId;
+  let referencesUpdated = 0;
+  walkDescriptors(descriptors, (desc) => {
+    if (desc.href === `#${oldId}`) {
+      desc.href = `#${newId}`;
+      referencesUpdated++;
+    }
+    if (desc.rt === `#${oldId}`) {
+      desc.rt = `#${newId}`;
+      referencesUpdated++;
+    }
+  });
+
+  const result: RenameResult = { id: newId, previousId: oldId, referencesUpdated };
+  if (typeof target.doc === "object" && target.doc?.href) {
+    result.docFile = target.doc.href;
+  }
+  fs.writeFileSync(absPath, serializeLike(root, content), "utf-8");
+  return result;
 }

--- a/packages/mcp/src/descriptor-store.ts
+++ b/packages/mcp/src/descriptor-store.ts
@@ -1,0 +1,119 @@
+/**
+ * Descriptor store - create descriptors in a JSON ALPS profile
+ *
+ * Like doc-store, edits the raw JSON surgically (preserving indentation
+ * and everything else in the profile) rather than re-serializing a
+ * normalized parse. Containers reference their children via href
+ * fragments, following ALPS best practice; missing children are created
+ * as top-level semantic descriptors.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { findDescriptorById } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+import type { AlpsDescriptor } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+import { serializeLike } from "./doc-store.js";
+
+export interface AddDescriptorInput {
+  id: string;
+  type?: "semantic" | "safe" | "unsafe" | "idempotent";
+  title?: string;
+  rt?: string;
+  tag?: string;
+  /** Child descriptor ids; referenced as href fragments from the new descriptor */
+  children?: string[];
+  /** Id of an existing descriptor to nest the new one inside (default: top level) */
+  parent?: string;
+}
+
+export interface AddDescriptorResult {
+  id: string;
+  /** Child ids that did not exist and were created as top-level semantic descriptors */
+  createdChildren: string[];
+  /** Warnings (e.g. rt target does not exist yet) */
+  warnings: string[];
+}
+
+/**
+ * Add a new descriptor to a JSON ALPS profile file
+ */
+export function addDescriptor(profilePath: string, input: AddDescriptorInput): AddDescriptorResult {
+  const absPath = path.resolve(profilePath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Profile file not found: ${profilePath}`);
+  }
+  const content = fs.readFileSync(absPath, "utf-8");
+  if (!content.trim().startsWith("{")) {
+    throw new Error(
+      "Writing descriptors is currently supported for JSON profiles only. " +
+        "Convert the XML profile to JSON, or edit the XML directly."
+    );
+  }
+
+  let root: { alps?: { descriptor?: unknown } };
+  try {
+    root = JSON.parse(content);
+  } catch (e) {
+    throw new Error(`Invalid JSON format: ${(e as Error).message}`);
+  }
+  if (!root.alps || typeof root.alps !== "object") {
+    throw new Error("Missing alps property");
+  }
+  if (!Array.isArray(root.alps.descriptor)) {
+    root.alps.descriptor = [];
+  }
+  const topLevel = root.alps.descriptor as AlpsDescriptor[];
+
+  if (findDescriptorById(topLevel, input.id)) {
+    throw new Error(`Descriptor already exists: ${input.id} (use alps_set_doc to update its documentation)`);
+  }
+
+  const warnings: string[] = [];
+  const descriptor: AlpsDescriptor = { id: input.id };
+  if (input.type && input.type !== "semantic") {
+    descriptor.type = input.type;
+  }
+  if (input.title) {
+    descriptor.title = input.title;
+  }
+  if (input.tag) {
+    descriptor.tag = input.tag;
+  }
+  if (input.rt) {
+    // Normalize a bare local id to a fragment reference
+    const rt = /^#|:|\//.test(input.rt) || input.rt.includes("#") ? input.rt : `#${input.rt}`;
+    descriptor.rt = rt;
+    const target = rt.startsWith("#") ? rt.substring(1) : null;
+    if (target && !findDescriptorById(topLevel, target)) {
+      warnings.push(`rt target "#${target}" does not exist yet`);
+    }
+  }
+
+  // Children: reference by href; create missing ones as top-level semantic descriptors
+  const createdChildren: string[] = [];
+  if (input.children && input.children.length > 0) {
+    descriptor.descriptor = input.children.map(childId => ({ href: `#${childId}` }));
+    for (const childId of input.children) {
+      if (!findDescriptorById(topLevel, childId) && childId !== input.id) {
+        topLevel.push({ id: childId });
+        createdChildren.push(childId);
+      }
+    }
+  }
+
+  if (input.parent) {
+    const parent = findDescriptorById(topLevel, input.parent);
+    if (!parent) {
+      throw new Error(`Parent descriptor not found: ${input.parent}`);
+    }
+    if (!Array.isArray(parent.descriptor)) {
+      parent.descriptor = [];
+    }
+    parent.descriptor.push(descriptor);
+  } else {
+    topLevel.push(descriptor);
+  }
+
+  fs.writeFileSync(absPath, serializeLike(root, content), "utf-8");
+  return { id: input.id, createdChildren, warnings };
+}

--- a/packages/mcp/src/descriptor-store.ts
+++ b/packages/mcp/src/descriptor-store.ts
@@ -63,9 +63,22 @@ export interface RenameResult {
 }
 
 /**
+ * Reject empty or whitespace-only descriptor ids before any mutation
+ */
+function assertValidId(id: string, label: string): void {
+  if (!id || id.trim() === "") {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+}
+
+/**
  * Add a new descriptor to a JSON ALPS profile file
  */
 export function addDescriptor(profilePath: string, input: AddDescriptorInput): AddDescriptorResult {
+  assertValidId(input.id, "Descriptor id");
+  for (const childId of input.children || []) {
+    assertValidId(childId, "Child descriptor id");
+  }
   const absPath = path.resolve(profilePath);
   if (!fs.existsSync(absPath)) {
     throw new Error(`Profile file not found: ${profilePath}`);
@@ -209,6 +222,7 @@ export function setDescriptorTags(profilePath: string, input: SetTagsInput): Set
  * still points at it and keeps working.
  */
 export function renameDescriptor(profilePath: string, oldId: string, newId: string): RenameResult {
+  assertValidId(newId, "New descriptor id");
   const absPath = path.resolve(profilePath);
   if (!fs.existsSync(absPath)) {
     throw new Error(`Profile file not found: ${profilePath}`);

--- a/packages/mcp/src/descriptor-store.ts
+++ b/packages/mcp/src/descriptor-store.ts
@@ -34,6 +34,24 @@ export interface AddDescriptorResult {
   warnings: string[];
 }
 
+export interface SetTagsInput {
+  id: string;
+  /** Tags to append (ones already present are ignored) */
+  add?: string[];
+  /** Tags to remove */
+  remove?: string[];
+}
+
+export interface SetTagsResult {
+  id: string;
+  /** Final tag list after the edit */
+  tags: string[];
+  /** Tags actually added (not already present) */
+  added: string[];
+  /** Tags actually removed (present before the edit) */
+  removed: string[];
+}
+
 /**
  * Add a new descriptor to a JSON ALPS profile file
  */
@@ -116,4 +134,58 @@ export function addDescriptor(profilePath: string, input: AddDescriptorInput): A
 
   fs.writeFileSync(absPath, serializeLike(root, content), "utf-8");
   return { id: input.id, createdChildren, warnings };
+}
+
+/**
+ * Add and/or remove tags in a descriptor's space-separated tag attribute.
+ * Removals are applied first, then additions are appended after the kept
+ * tags, which preserve their original order. The list is deduped and the
+ * tag property is deleted when it becomes empty.
+ */
+export function setDescriptorTags(profilePath: string, input: SetTagsInput): SetTagsResult {
+  if (!input.add?.length && !input.remove?.length) {
+    throw new Error("At least one of add or remove is required");
+  }
+  const absPath = path.resolve(profilePath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Profile file not found: ${profilePath}`);
+  }
+  const content = fs.readFileSync(absPath, "utf-8");
+  if (!content.trim().startsWith("{")) {
+    throw new Error(
+      "Writing tags is currently supported for JSON profiles only. " +
+        "Convert the XML profile to JSON, or edit the XML directly."
+    );
+  }
+
+  let root: { alps?: { descriptor?: unknown } };
+  try {
+    root = JSON.parse(content);
+  } catch (e) {
+    throw new Error(`Invalid JSON format: ${(e as Error).message}`);
+  }
+  const descriptor = findDescriptorById(root.alps?.descriptor, input.id);
+  if (!descriptor) {
+    throw new Error(`Descriptor not found: ${input.id}`);
+  }
+
+  const existing = [...new Set((descriptor.tag || "").split(/\s+/).filter(Boolean))];
+  const removeSet = new Set(input.remove || []);
+  const removed = existing.filter((tag) => removeSet.has(tag));
+  const tags = existing.filter((tag) => !removeSet.has(tag));
+  const added: string[] = [];
+  for (const tag of input.add || []) {
+    if (!tags.includes(tag) && !added.includes(tag)) {
+      added.push(tag);
+    }
+  }
+  tags.push(...added);
+
+  if (tags.length === 0) {
+    delete descriptor.tag;
+  } else {
+    descriptor.tag = tags.join(" ");
+  }
+  fs.writeFileSync(absPath, serializeLike(root, content), "utf-8");
+  return { id: input.id, tags, added, removed };
 }

--- a/packages/mcp/src/doc-store.test.ts
+++ b/packages/mcp/src/doc-store.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Doc Store Tests
+ *
+ * Tests inline/external doc placement, raw-JSON editing, and doc.href
+ * containment (including symlink escapes) against real temp directories.
+ */
+
+const {
+  setDescriptorDoc,
+  resolveDoc,
+  shouldExternalize,
+  INLINE_DOC_MAX_LENGTH,
+  DOC_DIR,
+} = require('./doc-store');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const PROFILE = {
+  alps: {
+    title: 'Test',
+    descriptor: [
+      {
+        id: 'Home',
+        type: 'semantic',
+        descriptor: [{ href: '#goCatalog' }, { id: 'greeting', type: 'semantic' }],
+      },
+      { id: 'Catalog', type: 'semantic', doc: { value: 'old doc', format: 'text' } },
+      { id: 'goCatalog', type: 'safe', rt: '#Catalog' },
+    ],
+  },
+};
+
+let dir: string;
+let profilePath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-store-'));
+  profilePath = path.join(dir, 'profile.json');
+  fs.writeFileSync(profilePath, JSON.stringify(PROFILE, null, 2) + '\n');
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const readProfile = () => JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+
+describe('shouldExternalize', () => {
+  it('keeps short single-line docs inline', () => {
+    expect(shouldExternalize('Short doc')).toBe(false);
+  });
+
+  it('externalizes long docs', () => {
+    expect(shouldExternalize('a'.repeat(INLINE_DOC_MAX_LENGTH + 1))).toBe(true);
+  });
+
+  it('externalizes multi-line docs', () => {
+    expect(shouldExternalize('# Title\n\nBody')).toBe(true);
+  });
+});
+
+describe('setDescriptorDoc', () => {
+  it('stores a short doc inline as a string', () => {
+    const result = setDescriptorDoc(profilePath, 'Home', 'Entry point.');
+    expect(result).toEqual({ id: 'Home', placement: 'inline' });
+    expect(readProfile().alps.descriptor[0].doc).toBe('Entry point.');
+  });
+
+  it('preserves object form when updating an existing inline doc', () => {
+    setDescriptorDoc(profilePath, 'Catalog', 'new doc');
+    expect(readProfile().alps.descriptor[1].doc).toEqual({ value: 'new doc', format: 'text' });
+  });
+
+  it('stores a large doc in an external alps/docs file linked via doc.href', () => {
+    const doc = '# Home\n\nDetailed documentation.\n\n- rule 1\n- rule 2';
+    const result = setDescriptorDoc(profilePath, 'Home', doc);
+    expect(result.placement).toBe('external');
+    expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
+    expect(readProfile().alps.descriptor[0].doc).toEqual({
+      href: `${DOC_DIR}/Home.md`,
+      format: 'markdown',
+    });
+    expect(fs.readFileSync(path.join(dir, DOC_DIR, 'Home.md'), 'utf-8')).toBe(doc + '\n');
+  });
+
+  it('keeps an existing external doc external on auto, even for short docs', () => {
+    setDescriptorDoc(profilePath, 'Home', '# Long\n\ndoc');
+    const result = setDescriptorDoc(profilePath, 'Home', 'Now short.');
+    expect(result.placement).toBe('external');
+    expect(fs.readFileSync(path.join(dir, DOC_DIR, 'Home.md'), 'utf-8')).toBe('Now short.\n');
+  });
+
+  it('updates a custom local doc.href in place, preserving its format', () => {
+    const profile = {
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', doc: { href: 'docs/home.txt', format: 'text' } },
+        ],
+      },
+    };
+    fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+    const result = setDescriptorDoc(profilePath, 'Home', 'Updated doc.');
+    expect(result).toEqual({ id: 'Home', placement: 'external', docFile: 'docs/home.txt' });
+    expect(fs.readFileSync(path.join(dir, 'docs/home.txt'), 'utf-8')).toBe('Updated doc.\n');
+    expect(readProfile().alps.descriptor[0].doc).toEqual({
+      href: 'docs/home.txt',
+      format: 'text',
+    });
+  });
+
+  it('forces inline placement and reports the orphaned doc file', () => {
+    setDescriptorDoc(profilePath, 'Home', '# Long\n\ndoc');
+    const result = setDescriptorDoc(profilePath, 'Home', 'Inline now.', 'inline');
+    expect(result).toEqual({
+      id: 'Home',
+      placement: 'inline',
+      orphanedDocFile: `${DOC_DIR}/Home.md`,
+    });
+    expect(readProfile().alps.descriptor[0].doc).toBe('Inline now.');
+    expect(fs.existsSync(path.join(dir, DOC_DIR, 'Home.md'))).toBe(true);
+  });
+
+  it('forces external placement for short docs', () => {
+    const result = setDescriptorDoc(profilePath, 'Home', 'Short.', 'external');
+    expect(result.placement).toBe('external');
+    expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
+  });
+
+  it('updates nested descriptors', () => {
+    setDescriptorDoc(profilePath, 'greeting', 'A greeting.');
+    expect(readProfile().alps.descriptor[0].descriptor[1].doc).toBe('A greeting.');
+  });
+
+  it('sanitizes descriptor ids in file names', () => {
+    const profile = { alps: { descriptor: [{ id: 'a/b c', type: 'semantic' }] } };
+    fs.writeFileSync(profilePath, JSON.stringify(profile));
+    const result = setDescriptorDoc(profilePath, 'a/b c', 'x\ny');
+    expect(result.docFile).toBe(`${DOC_DIR}/a-b-c.md`);
+  });
+
+  it('preserves the original indentation', () => {
+    fs.writeFileSync(profilePath, JSON.stringify(PROFILE, null, 4) + '\n');
+    setDescriptorDoc(profilePath, 'Home', 'Doc.');
+    const content = fs.readFileSync(profilePath, 'utf-8');
+    expect(content).toContain('\n    "alps"');
+    expect(content.endsWith('\n')).toBe(true);
+  });
+
+  it('writes through symlinks that stay inside the profile directory', () => {
+    fs.mkdirSync(path.join(dir, 'real-docs'));
+    fs.symlinkSync(path.join(dir, 'real-docs'), path.join(dir, 'linkdocs'));
+    const profile = {
+      alps: { descriptor: [{ id: 'Home', type: 'semantic', doc: { href: 'linkdocs/home.md' } }] },
+    };
+    fs.writeFileSync(profilePath, JSON.stringify(profile));
+    const result = setDescriptorDoc(profilePath, 'Home', 'Linked doc.');
+    expect(result).toEqual({ id: 'Home', placement: 'external', docFile: 'linkdocs/home.md' });
+    expect(fs.readFileSync(path.join(dir, 'real-docs', 'home.md'), 'utf-8')).toBe('Linked doc.\n');
+  });
+
+  it('rejects writes through symlinks escaping the profile directory', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-store-outside-'));
+    try {
+      fs.symlinkSync(outside, path.join(dir, 'alps'));
+      expect(() => setDescriptorDoc(profilePath, 'Home', 'x\ny')).toThrow('Unsafe doc path');
+      expect(fs.readdirSync(outside)).toEqual([]);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('does not reuse unsafe existing doc.href values as write targets', () => {
+    const unsafeHrefs = ['../escape.md', '/etc/escape.md', 'file:///etc/escape.md', 'a\\b.md'];
+    for (const href of unsafeHrefs) {
+      const profile = {
+        alps: { descriptor: [{ id: 'Home', type: 'semantic', doc: { href } }] },
+      };
+      fs.writeFileSync(profilePath, JSON.stringify(profile));
+      const result = setDescriptorDoc(profilePath, 'Home', 'x\ny');
+      expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
+      expect(fs.existsSync(path.join(dir, '..', 'escape.md'))).toBe(false);
+    }
+  });
+
+  it('rejects unknown descriptor ids', () => {
+    expect(() => setDescriptorDoc(profilePath, 'Nope', 'doc')).toThrow('Descriptor not found');
+  });
+
+  it('rejects XML profiles', () => {
+    const xmlPath = path.join(dir, 'profile.xml');
+    fs.writeFileSync(xmlPath, '<alps><descriptor id="Home"/></alps>');
+    expect(() => setDescriptorDoc(xmlPath, 'Home', 'doc')).toThrow('JSON profiles only');
+  });
+
+  it('rejects missing files', () => {
+    expect(() => setDescriptorDoc(path.join(dir, 'none.json'), 'Home', 'doc')).toThrow(
+      'Profile file not found'
+    );
+  });
+});
+
+describe('resolveDoc', () => {
+  it('resolves inline string docs', () => {
+    expect(resolveDoc(dir, 'hello')).toEqual({ text: 'hello' });
+  });
+
+  it('reads external doc files', () => {
+    setDescriptorDoc(profilePath, 'Home', '# Doc\n\nbody');
+    const resolved = resolveDoc(dir, { href: `${DOC_DIR}/Home.md`, format: 'markdown' });
+    expect(resolved).toEqual({
+      text: '# Doc\n\nbody\n',
+      href: `${DOC_DIR}/Home.md`,
+      format: 'markdown',
+    });
+  });
+
+  it('falls back to the inline value when the external file is missing', () => {
+    const resolved = resolveDoc(dir, { href: `${DOC_DIR}/missing.md`, value: 'fallback' });
+    expect(resolved?.text).toBe('fallback');
+  });
+
+  it('does not fetch http urls', () => {
+    const resolved = resolveDoc(dir, { href: 'https://example.com/doc.md', value: 'inline' });
+    expect(resolved).toEqual({ text: 'inline', href: 'https://example.com/doc.md', format: undefined });
+  });
+
+  it('does not read through symlinks escaping the profile directory', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-store-outside-'));
+    try {
+      fs.writeFileSync(path.join(outside, 'secret.md'), 'secret');
+      fs.symlinkSync(outside, path.join(dir, 'extdocs'));
+      const resolved = resolveDoc(dir, { href: 'extdocs/secret.md', value: 'fallback' });
+      expect(resolved?.text).toBe('fallback');
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read hrefs that escape the profile directory', () => {
+    const outside = path.join(path.dirname(dir), 'outside-secret.md');
+    fs.writeFileSync(outside, 'secret');
+    try {
+      for (const href of [`../${path.basename(outside)}`, outside, `file://${outside}`]) {
+        const resolved = resolveDoc(dir, { href, value: 'fallback' });
+        expect(resolved?.text).toBe('fallback');
+      }
+    } finally {
+      fs.rmSync(outside, { force: true });
+    }
+  });
+
+  it('returns undefined for missing docs', () => {
+    expect(resolveDoc(dir, undefined)).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/doc-store.test.ts
+++ b/packages/mcp/src/doc-store.test.ts
@@ -8,6 +8,7 @@
 const {
   setDescriptorDoc,
   resolveDoc,
+  resolveSafeLocalPath,
   shouldExternalize,
   INLINE_DOC_MAX_LENGTH,
   DOC_DIR,
@@ -198,6 +199,11 @@ describe('setDescriptorDoc', () => {
       'Profile file not found'
     );
   });
+
+  it('rejects invalid JSON profiles', () => {
+    fs.writeFileSync(profilePath, '{');
+    expect(() => setDescriptorDoc(profilePath, 'Home', 'doc')).toThrow('Invalid JSON format');
+  });
 });
 
 describe('resolveDoc', () => {
@@ -252,5 +258,9 @@ describe('resolveDoc', () => {
 
   it('returns undefined for missing docs', () => {
     expect(resolveDoc(dir, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the base directory cannot be resolved', () => {
+    expect(resolveSafeLocalPath(path.join(dir, 'missing-base'), 'doc.md')).toBeUndefined();
   });
 });

--- a/packages/mcp/src/doc-store.test.ts
+++ b/packages/mcp/src/doc-store.test.ts
@@ -128,6 +128,13 @@ describe('setDescriptorDoc', () => {
     expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
   });
 
+  it('does not add a second newline when writing external docs', () => {
+    const result = setDescriptorDoc(profilePath, 'Home', 'Already newline\n', 'external');
+
+    expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
+    expect(fs.readFileSync(path.join(dir, DOC_DIR, 'Home.md'), 'utf-8')).toBe('Already newline\n');
+  });
+
   it('updates nested descriptors', () => {
     setDescriptorDoc(profilePath, 'greeting', 'A greeting.');
     expect(readProfile().alps.descriptor[0].descriptor[1].doc).toBe('A greeting.');
@@ -224,6 +231,14 @@ describe('resolveDoc', () => {
   it('falls back to the inline value when the external file is missing', () => {
     const resolved = resolveDoc(dir, { href: `${DOC_DIR}/missing.md`, value: 'fallback' });
     expect(resolved?.text).toBe('fallback');
+  });
+
+  it('returns an empty string for object docs without value text', () => {
+    expect(resolveDoc(dir, { format: 'text' })).toEqual({
+      text: '',
+      href: undefined,
+      format: 'text',
+    });
   });
 
   it('does not fetch http urls', () => {

--- a/packages/mcp/src/doc-store.ts
+++ b/packages/mcp/src/doc-store.ts
@@ -1,0 +1,209 @@
+/**
+ * Doc store - descriptor documentation with automatic externalization
+ *
+ * Short docs are stored inline in the ALPS profile. When a doc is too large
+ * for inline use (long text, multi-line Markdown), it is written to
+ * `alps/docs/<descriptor-id>.md` next to the profile and linked from the
+ * descriptor via `doc.href`, keeping the profile compact while allowing
+ * rich documentation.
+ *
+ * The `alps/` directory is the home for auxiliary design information:
+ * docs/ (descriptor documentation), rels/ (link relation definitions),
+ * links/ (compacted summaries of external link targets).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { findDescriptorById } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+import type { AlpsDoc } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+
+export const DOC_DIR = "alps/docs";
+
+/** Docs longer than this (or multi-line) are stored in an external file */
+export const INLINE_DOC_MAX_LENGTH = 200;
+
+export type DocPlacement = "auto" | "inline" | "external";
+
+export interface SetDocResult {
+  id: string;
+  placement: "inline" | "external";
+  /** Path of the external doc file (relative to the profile), when external */
+  docFile?: string;
+  /** Previous external doc file left behind after switching to inline */
+  orphanedDocFile?: string;
+}
+
+/**
+ * Decide whether a doc should be stored in an external file
+ */
+export function shouldExternalize(doc: string): boolean {
+  return doc.length > INLINE_DOC_MAX_LENGTH || doc.includes("\n");
+}
+
+/**
+ * Set or update the doc of a descriptor in a JSON ALPS profile file.
+ *
+ * With placement 'auto', the doc is stored externally when it is large
+ * (see shouldExternalize) or when the descriptor already links a local
+ * doc file via doc.href (to avoid churn between inline and external).
+ */
+export function setDescriptorDoc(
+  profilePath: string,
+  id: string,
+  doc: string,
+  placement: DocPlacement = "auto"
+): SetDocResult {
+  const absPath = path.resolve(profilePath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Profile file not found: ${profilePath}`);
+  }
+
+  const content = fs.readFileSync(absPath, "utf-8");
+  if (!content.trim().startsWith("{")) {
+    throw new Error(
+      "Writing docs is currently supported for JSON profiles only. " +
+        "Convert the XML profile to JSON, or edit the XML directly."
+    );
+  }
+
+  let root: any;
+  try {
+    root = JSON.parse(content);
+  } catch (e) {
+    throw new Error(`Invalid JSON format: ${(e as Error).message}`);
+  }
+
+  const descriptor = findDescriptorById(root?.alps?.descriptor, id);
+  if (!descriptor) {
+    throw new Error(`Descriptor not found: ${id}`);
+  }
+
+  const baseDir = path.dirname(absPath);
+  const existingDoc: string | AlpsDoc | undefined = descriptor.doc;
+  const existingHref =
+    typeof existingDoc === "object" && existingDoc?.href ? existingDoc.href : undefined;
+  // Unsafe hrefs (absolute, ../ traversal, schemes) are never reused as write targets
+  const hasExternalDoc =
+    existingHref !== undefined && resolveSafeLocalPath(baseDir, existingHref) !== undefined;
+
+  let external: boolean;
+  if (placement === "auto") {
+    external = hasExternalDoc || shouldExternalize(doc);
+  } else {
+    external = placement === "external";
+  }
+
+  const result: SetDocResult = { id, placement: external ? "external" : "inline" };
+
+  if (external) {
+    // Reuse the existing local doc file location when present
+    const docFile = hasExternalDoc ? existingHref! : `${DOC_DIR}/${safeFileName(id)}.md`;
+    const docFilePath = resolveSafeLocalPath(baseDir, docFile);
+    if (!docFilePath) {
+      // Reachable only when the default doc dir is a symlink escaping baseDir
+      throw new Error(`Unsafe doc path: ${docFile}`);
+    }
+    fs.mkdirSync(path.dirname(docFilePath), { recursive: true });
+    fs.writeFileSync(docFilePath, doc.endsWith("\n") ? doc : `${doc}\n`, "utf-8");
+    const format =
+      typeof existingDoc === "object" && hasExternalDoc && existingDoc.format
+        ? existingDoc.format
+        : "markdown";
+    descriptor.doc = { href: docFile, format };
+    result.docFile = docFile;
+  } else {
+    if (hasExternalDoc) {
+      // The previous external file is kept; deleting user files silently is unsafe
+      result.orphanedDocFile = existingHref;
+    }
+    if (typeof existingDoc === "object" && existingDoc !== null && !hasExternalDoc) {
+      // Preserve object form (and format) of an existing inline doc
+      const inlineDoc: AlpsDoc = { ...existingDoc, value: doc };
+      delete inlineDoc.href;
+      descriptor.doc = inlineDoc;
+    } else {
+      descriptor.doc = doc;
+    }
+  }
+
+  fs.writeFileSync(absPath, serializeLike(root, content), "utf-8");
+  return result;
+}
+
+/**
+ * Resolve the doc of a descriptor, reading external doc files (e.g. alps/docs/)
+ */
+export function resolveDoc(
+  baseDir: string,
+  doc: string | AlpsDoc | undefined
+): { text: string; href?: string; format?: string } | undefined {
+  if (doc === undefined || doc === null) {
+    return undefined;
+  }
+  if (typeof doc === "string") {
+    return { text: doc };
+  }
+  if (doc.href) {
+    const docPath = resolveSafeLocalPath(baseDir, doc.href);
+    if (docPath && fs.existsSync(docPath)) {
+      return { text: fs.readFileSync(docPath, "utf-8"), href: doc.href, format: doc.format };
+    }
+  }
+  return { text: doc.value || "", href: doc.href, format: doc.format };
+}
+
+/**
+ * Resolve a doc href against the profile directory, rejecting anything
+ * that escapes it: URL schemes ("http:", "file:", Windows drives),
+ * protocol-relative or absolute paths, backslashes, and ../ traversal.
+ * Symlinks inside the profile directory are legitimate (e.g. compat
+ * links keeping old layouts working), but their real targets must stay
+ * inside it. Returns the absolute path, or undefined when unsafe.
+ */
+function resolveSafeLocalPath(baseDir: string, href: string): string | undefined {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
+    return undefined;
+  }
+  if (href.startsWith("//") || href.includes("\\") || path.isAbsolute(href)) {
+    return undefined;
+  }
+  const abs = path.resolve(baseDir, href);
+  const rel = path.relative(baseDir, abs);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    return undefined;
+  }
+  // Compare real paths so a symlinked component cannot escape baseDir.
+  // The target file may not exist yet (first write), so check the
+  // deepest existing ancestor instead.
+  try {
+    const baseReal = fs.realpathSync(baseDir);
+    let existing = abs;
+    while (!fs.existsSync(existing)) {
+      existing = path.dirname(existing);
+    }
+    const existingReal = fs.realpathSync(existing);
+    if (existingReal !== baseReal && !existingReal.startsWith(baseReal + path.sep)) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return abs;
+}
+
+/**
+ * Turn a descriptor id into a safe file name for alps/docs/
+ */
+function safeFileName(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+/**
+ * Serialize JSON keeping the original file's indentation and trailing newline
+ */
+function serializeLike(root: unknown, original: string): string {
+  const indentMatch = original.match(/^([ \t]+)"/m);
+  const indent = indentMatch ? indentMatch[1] : "  ";
+  const json = JSON.stringify(root, null, indent);
+  return original.endsWith("\n") ? `${json}\n` : json;
+}

--- a/packages/mcp/src/doc-store.ts
+++ b/packages/mcp/src/doc-store.ts
@@ -153,14 +153,15 @@ export function resolveDoc(
 }
 
 /**
- * Resolve a doc href against the profile directory, rejecting anything
- * that escapes it: URL schemes ("http:", "file:", Windows drives),
- * protocol-relative or absolute paths, backslashes, and ../ traversal.
- * Symlinks inside the profile directory are legitimate (e.g. compat
- * links keeping old layouts working), but their real targets must stay
- * inside it. Returns the absolute path, or undefined when unsafe.
+ * Resolve a local href (doc.href, describedby link) against the profile
+ * directory, rejecting anything that escapes it: URL schemes ("http:",
+ * "file:", Windows drives), protocol-relative or absolute paths,
+ * backslashes, and ../ traversal. Symlinks inside the profile directory
+ * are legitimate (e.g. compat links keeping old layouts working), but
+ * their real targets must stay inside it. Returns the absolute path, or
+ * undefined when unsafe.
  */
-function resolveSafeLocalPath(baseDir: string, href: string): string | undefined {
+export function resolveSafeLocalPath(baseDir: string, href: string): string | undefined {
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
     return undefined;
   }

--- a/packages/mcp/src/doc-store.ts
+++ b/packages/mcp/src/doc-store.ts
@@ -201,7 +201,7 @@ function safeFileName(id: string): string {
 /**
  * Serialize JSON keeping the original file's indentation and trailing newline
  */
-function serializeLike(root: unknown, original: string): string {
+export function serializeLike(root: unknown, original: string): string {
   const indentMatch = original.match(/^([ \t]+)"/m);
   const indent = indentMatch ? indentMatch[1] : "  ";
   const json = JSON.stringify(root, null, indent);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,7 +28,7 @@ import { dotToSvg } from "@alps-asd/app-state-diagram/generator/svg-generator.js
 import { generateMermaid } from "@alps-asd/app-state-diagram/generator/mermaid-generator.js";
 import { FileResolver } from "@alps-asd/app-state-diagram/resolver/index.js";
 import { extractGraph, findPaths, formatPath, findContainers, getDescriptorIdsByTags } from "@alps-asd/app-state-diagram/graph/index.js";
-import { addDescriptor, setDescriptorTags } from "./descriptor-store.js";
+import { addDescriptor, setDescriptorTags, renameDescriptor } from "./descriptor-store.js";
 import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
 
 // Crawler package is optional (not yet published)
@@ -380,6 +380,29 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["file", "id"],
         },
       },
+      {
+        name: "alps_rename",
+        description:
+          "Rename a descriptor in a JSON ALPS profile and update all local references: href and rt #fragments at any nesting depth. External references (file.json#id) are left untouched. An external doc file (doc.href) keeps its old file name but stays linked.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON only for writes)",
+            },
+            id: {
+              type: "string",
+              description: "Current descriptor id",
+            },
+            newId: {
+              type: "string",
+              description: "New descriptor id",
+            },
+          },
+          required: ["file", "id", "newId"],
+        },
+      },
     ],
   };
 });
@@ -416,6 +439,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return handleAlpsAddDescriptor(args);
     case "alps_set_tags":
       return handleAlpsSetTags(args);
+    case "alps_rename":
+      return handleAlpsRename(args);
     default:
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -537,6 +562,30 @@ export async function handleAlpsSetTags(args: Record<string, unknown> | undefine
       remove: args?.remove as string[] | undefined,
     });
     return jsonResult(result);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Rename a descriptor and update local #fragment references across a JSON profile
+ */
+export async function handleAlpsRename(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const id = args?.id as string | undefined;
+  const newId = args?.newId as string | undefined;
+  if (!file || !id || !newId) {
+    return {
+      content: [{ type: "text", text: "Error: file, id, and newId are required" }],
+      isError: true,
+    };
+  }
+  try {
+    return jsonResult(renameDescriptor(file, id, newId));
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,6 +28,7 @@ import { dotToSvg } from "@alps-asd/app-state-diagram/generator/svg-generator.js
 import { generateMermaid } from "@alps-asd/app-state-diagram/generator/mermaid-generator.js";
 import { FileResolver } from "@alps-asd/app-state-diagram/resolver/index.js";
 import { extractGraph, findPaths, formatPath, findContainers, getDescriptorIdsByTags } from "@alps-asd/app-state-diagram/graph/index.js";
+import { addDescriptor } from "./descriptor-store.js";
 import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
 
 // Crawler package is optional (not yet published)
@@ -302,6 +303,54 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["file", "id", "doc"],
         },
       },
+      {
+        name: "alps_add_descriptor",
+        description: "Add a new descriptor to a JSON ALPS profile. Containers reference children via href fragments; missing children are created as top-level semantic descriptors. Example: register name and age as person -> id: person, children: [name, age].",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON only for writes)",
+            },
+            id: {
+              type: "string",
+              description: "New descriptor id",
+            },
+            type: {
+              type: "string",
+              enum: ["semantic", "safe", "unsafe", "idempotent"],
+              description: "Descriptor type (default: semantic)",
+            },
+            title: {
+              type: "string",
+              description: "Human-readable title",
+            },
+            doc: {
+              type: "string",
+              description: "Documentation; long or multi-line docs are auto-externalized to alps/docs/<id>.md",
+            },
+            rt: {
+              type: "string",
+              description: "Transition target state id (for safe/unsafe/idempotent); bare ids are normalized to #fragments",
+            },
+            tag: {
+              type: "string",
+              description: "Space-separated tags",
+            },
+            children: {
+              type: "array",
+              items: { type: "string" },
+              description: "Child descriptor ids, referenced as href fragments; missing ones are created as semantic leaf descriptors",
+            },
+            parent: {
+              type: "string",
+              description: "Nest the new descriptor inside this existing descriptor (default: top level)",
+            },
+          },
+          required: ["file", "id"],
+        },
+      },
     ],
   };
 });
@@ -334,6 +383,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return handleAlpsPaths(args);
     case "alps_set_doc":
       return handleAlpsSetDoc(args);
+    case "alps_add_descriptor":
+      return handleAlpsAddDescriptor(args);
     default:
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -391,6 +442,43 @@ export async function handleValidateAlps(args: Record<string, unknown> | undefin
     };
   } catch (error) {
     /* istanbul ignore next */
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Add a new descriptor (optionally nested or with href children) to a JSON profile
+ */
+export async function handleAlpsAddDescriptor(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const id = args?.id as string | undefined;
+  if (!file || !id) {
+    return {
+      content: [{ type: "text", text: "Error: file and id are required" }],
+      isError: true,
+    };
+  }
+  try {
+    const result = addDescriptor(file, {
+      id,
+      type: args?.type as "semantic" | "safe" | "unsafe" | "idempotent" | undefined,
+      title: args?.title as string | undefined,
+      rt: args?.rt as string | undefined,
+      tag: args?.tag as string | undefined,
+      children: args?.children as string[] | undefined,
+      parent: args?.parent as string | undefined,
+    });
+    const doc = args?.doc as string | undefined;
+    let docResult: unknown;
+    if (doc) {
+      docResult = setDescriptorDoc(file, id, doc, "auto");
+    }
+    return jsonResult({ ...result, ...(docResult ? { doc: docResult } : {}) });
+  } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       content: [{ type: "text", text: `Error: ${errorMessage}` }],

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -27,7 +27,7 @@ import { generateDot } from "@alps-asd/app-state-diagram/generator/dot-generator
 import { dotToSvg } from "@alps-asd/app-state-diagram/generator/svg-generator.js";
 import { generateMermaid } from "@alps-asd/app-state-diagram/generator/mermaid-generator.js";
 import { FileResolver } from "@alps-asd/app-state-diagram/resolver/index.js";
-import { extractGraph, findPaths, formatPath, findContainers } from "@alps-asd/app-state-diagram/graph/index.js";
+import { extractGraph, findPaths, formatPath, findContainers, getDescriptorIdsByTags } from "@alps-asd/app-state-diagram/graph/index.js";
 import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
 
 // Crawler package is optional (not yet published)
@@ -91,6 +91,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: "string",
               description: "Path to ALPS profile file (alternative to alps_content)",
             },
+            tag: {
+              type: "string",
+              description: "Filter the diagram to descriptors with these tags (space or comma separated). Shows the induced subgraph: tagged nodes plus endpoints of tagged transitions.",
+            },
+            output: {
+              type: "string",
+              description: "Write the SVG to this file path and return the path instead of inline SVG (recommended for large diagrams)",
+            },
           },
         },
       },
@@ -107,6 +115,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             alps_path: {
               type: "string",
               description: "Path to ALPS profile file (alternative to alps_content)",
+            },
+            tag: {
+              type: "string",
+              description: "Filter the diagram to descriptors with these tags (space or comma separated). Shows the induced subgraph: tagged nodes plus endpoints of tagged transitions.",
             },
           },
         },
@@ -194,11 +206,16 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             tag: {
               type: "string",
-              description: "Filter by tag",
+              description: "Filter by tag(s), space or comma separated (OR match against the descriptor's space-separated tags)",
             },
             text: {
               type: "string",
               description: "Case-insensitive text search in id, title, and doc",
+            },
+            format: {
+              type: "string",
+              enum: ["json", "markdown"],
+              description: "Output format: json (default) or a Markdown table (ID, Type, Title, Tags, Doc) for direct display in chat",
             },
           },
           required: ["file"],
@@ -382,6 +399,50 @@ export async function handleValidateAlps(args: Record<string, unknown> | undefin
   }
 }
 
+/**
+ * Render descriptor summaries as a Markdown table for chat display
+ */
+function descriptorsToMarkdownTable(
+  rows: Array<{ id?: string; type: string; title?: string; tags?: string[]; doc?: string }>
+): string {
+  if (rows.length === 0) {
+    return "No descriptors match.";
+  }
+  const escapeCell = (value: string): string => value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+  const lines = [
+    "| ID | Type | Title | Tags | Doc |",
+    "| :-- | :-- | :-- | :-- | :-- |",
+  ];
+  for (const row of rows) {
+    lines.push(
+      `| ${escapeCell(row.id || "")} | ${row.type} | ${escapeCell(row.title || "")} | ${escapeCell((row.tags || []).join(" "))} | ${escapeCell(row.doc || "")} |`
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Resolve the optional tag filter for diagram tools.
+ * Returns null when no tags are requested.
+ */
+function resolveTagFilter(
+  document: AlpsDocument,
+  tagParam: string | undefined
+): { filterIds: Set<string> | null; error?: string } {
+  if (!tagParam) {
+    return { filterIds: null };
+  }
+  const tags = tagParam.split(/[\s,]+/).filter(Boolean);
+  if (tags.length === 0) {
+    return { filterIds: null };
+  }
+  const filterIds = getDescriptorIdsByTags(document, tags);
+  if (filterIds.size === 0) {
+    return { filterIds, error: `No descriptors match tag(s): ${tags.join(", ")}` };
+  }
+  return { filterIds };
+}
+
 export async function handleAlps2Svg(args: Record<string, unknown> | undefined) {
   let alpsContent = args?.alps_content as string | undefined;
   const alpsPath = args?.alps_path as string | undefined;
@@ -406,8 +467,25 @@ export async function handleAlps2Svg(args: Record<string, unknown> | undefined) 
 
   try {
     const document = parseAlpsAuto(alpsContent);
-    const dot = generateDot(document);
+    const { filterIds, error } = resolveTagFilter(document, args?.tag as string | undefined);
+    if (error) {
+      return { content: [{ type: "text", text: error }], isError: true };
+    }
+    const dot = generateDot(document, "id", filterIds);
+    if (!dot) {
+      return { content: [{ type: "text", text: "No diagram nodes match the selected tags." }] };
+    }
     const svg = await dotToSvg(dot);
+
+    const output = args?.output as string | undefined;
+    if (output) {
+      const outPath = path.resolve(output);
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      fs.writeFileSync(outPath, svg, "utf-8");
+      return {
+        content: [{ type: "text", text: `✅ SVG written to ${outPath} (${svg.length} bytes)` }],
+      };
+    }
 
     return {
       content: [{ type: "text", text: `✅ SVG generated (${svg.length} bytes)\n\n\`\`\`svg\n${svg}\n\`\`\`` }],
@@ -447,7 +525,14 @@ export async function handleAlps2Mermaid(args: Record<string, unknown> | undefin
 
   try {
     const document = parseAlpsAuto(alpsContent);
-    const mermaid = generateMermaid(document);
+    const { filterIds, error } = resolveTagFilter(document, args?.tag as string | undefined);
+    if (error) {
+      return { content: [{ type: "text", text: error }], isError: true };
+    }
+    const mermaid = generateMermaid(document, filterIds);
+    if (!mermaid) {
+      return { content: [{ type: "text", text: "No diagram nodes match the selected tags." }] };
+    }
 
     return {
       content: [{ type: "text", text: `✅ Mermaid classDiagram generated\n\n\`\`\`mermaid\n${mermaid}\`\`\`` }],
@@ -796,6 +881,8 @@ export async function handleAlpsSearch(args: Record<string, unknown> | undefined
     const { document } = await loadProfile(file);
     const descriptors = allDescriptors(document);
     const needle = text?.toLowerCase();
+    const tagList = tag ? tag.split(/[\s,]+/).filter(Boolean) : [];
+    const tagSet = tagList.length > 0 ? new Set(tagList) : null;
     const matches = descriptors.filter((desc) => {
       if (!desc.id) {
         return false;
@@ -803,7 +890,7 @@ export async function handleAlpsSearch(args: Record<string, unknown> | undefined
       if (type && (desc.type || "semantic") !== type) {
         return false;
       }
-      if (tag && !descriptorTags(desc).includes(tag)) {
+      if (tagSet && !descriptorTags(desc).some((t) => tagSet.has(t))) {
         return false;
       }
       if (needle) {
@@ -814,6 +901,9 @@ export async function handleAlpsSearch(args: Record<string, unknown> | undefined
       }
       return true;
     });
+    if ((args?.format as string | undefined) === "markdown") {
+      return { content: [{ type: "text", text: descriptorsToMarkdownTable(matches.map(summarize)) }] };
+    }
     return jsonResult({ count: matches.length, descriptors: matches.map(summarize) });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -29,7 +29,7 @@ import { generateMermaid } from "@alps-asd/app-state-diagram/generator/mermaid-g
 import { FileResolver } from "@alps-asd/app-state-diagram/resolver/index.js";
 import { extractGraph, findPaths, formatPath, findContainers, getDescriptorIdsByTags } from "@alps-asd/app-state-diagram/graph/index.js";
 import { addDescriptor, setDescriptorTags, renameDescriptor } from "./descriptor-store.js";
-import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
+import { setDescriptorDoc, resolveDoc, resolveSafeLocalPath, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
 
 // Crawler package is optional (not yet published)
 // import { AlpsCrawler } from "@alps-asd/crawler";
@@ -225,7 +225,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "alps_descriptor",
         description:
-          "Get full details of one descriptor: definition, resolved documentation (external alps/ doc files are read and inlined), containing states, and incoming/outgoing transitions.",
+          "Get full details of one descriptor: definition, resolved documentation and rel=\"describedby\" links (local files are read and inlined; http(s) links are returned unresolved), containing states, and incoming/outgoing transitions.",
         inputSchema: {
           type: "object" as const,
           properties: {
@@ -1110,6 +1110,33 @@ export async function handleAlpsSearch(args: Record<string, unknown> | undefined
   }
 }
 
+/**
+ * Resolve rel="describedby" links on a descriptor. Local files inside the
+ * profile directory are read and inlined as text; http(s) and unsafe hrefs
+ * are returned unresolved.
+ */
+function resolveDescribedBy(
+  baseDir: string,
+  descriptor: AlpsDescriptor
+): Array<{ rel: string; href: string; text?: string }> | undefined {
+  const link = descriptor.link;
+  if (!link) {
+    return undefined;
+  }
+  const links = Array.isArray(link) ? link : [link];
+  const describedBy = links.filter((l) => l?.rel === "describedby" && l.href);
+  if (describedBy.length === 0) {
+    return undefined;
+  }
+  return describedBy.map((l) => {
+    const localPath = resolveSafeLocalPath(baseDir, l.href);
+    if (localPath && fs.existsSync(localPath)) {
+      return { rel: l.rel, href: l.href, text: fs.readFileSync(localPath, "utf-8") };
+    }
+    return { rel: l.rel, href: l.href };
+  });
+}
+
 export async function handleAlpsDescriptor(args: Record<string, unknown> | undefined) {
   const file = args?.file as string | undefined;
   const id = args?.id as string | undefined;
@@ -1132,6 +1159,7 @@ export async function handleAlpsDescriptor(args: Record<string, unknown> | undef
     return jsonResult({
       descriptor,
       doc: resolveDoc(baseDir, descriptor.doc),
+      describedBy: resolveDescribedBy(baseDir, descriptor),
       containedBy: findContainers(id, descriptors),
       outgoingTransitions: graph.transitions
         .filter((t) => t.from.includes(id))

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -20,11 +20,15 @@ import { promisify } from "util";
 const execAsync = promisify(exec);
 
 // Import from CLI package
-import { parseAlpsAuto } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+import { parseAlpsAuto, docText, findDescriptorById, walkDescriptors } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+import type { AlpsDocument, AlpsDescriptor } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
 import { AlpsValidator } from "@alps-asd/app-state-diagram/validator/index.js";
 import { generateDot } from "@alps-asd/app-state-diagram/generator/dot-generator.js";
 import { dotToSvg } from "@alps-asd/app-state-diagram/generator/svg-generator.js";
 import { generateMermaid } from "@alps-asd/app-state-diagram/generator/mermaid-generator.js";
+import { FileResolver } from "@alps-asd/app-state-diagram/resolver/index.js";
+import { extractGraph, findPaths, formatPath, findContainers } from "@alps-asd/app-state-diagram/graph/index.js";
+import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
 
 // Crawler package is optional (not yet published)
 // import { AlpsCrawler } from "@alps-asd/crawler";
@@ -157,6 +161,130 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
+      {
+        name: "alps_overview",
+        description:
+          "Summarize an ALPS profile: title, application states, transitions (with from/to states), and tags. Use this first to understand the application state model.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON or XML)",
+            },
+          },
+          required: ["file"],
+        },
+      },
+      {
+        name: "alps_search",
+        description:
+          "Filter descriptors in an ALPS profile by type, tag, and/or free text (matched against id, title, and doc). Returns compact summaries.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON or XML)",
+            },
+            type: {
+              type: "string",
+              enum: ["semantic", "safe", "unsafe", "idempotent"],
+              description: "Filter by descriptor type",
+            },
+            tag: {
+              type: "string",
+              description: "Filter by tag",
+            },
+            text: {
+              type: "string",
+              description: "Case-insensitive text search in id, title, and doc",
+            },
+          },
+          required: ["file"],
+        },
+      },
+      {
+        name: "alps_descriptor",
+        description:
+          "Get full details of one descriptor: definition, resolved documentation (external alps/ doc files are read and inlined), containing states, and incoming/outgoing transitions.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON or XML)",
+            },
+            id: {
+              type: "string",
+              description: "Descriptor id",
+            },
+          },
+          required: ["file", "id"],
+        },
+      },
+      {
+        name: "alps_paths",
+        description:
+          "Enumerate transition paths from one application state to another, e.g. all ways a user can get from Home to OrderConfirmation.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON or XML)",
+            },
+            from: {
+              type: "string",
+              description: "Starting state id",
+            },
+            to: {
+              type: "string",
+              description: "Target state id",
+            },
+            maxPaths: {
+              type: "number",
+              minimum: 1,
+              maximum: 50,
+              description: "Maximum paths (default 10)",
+            },
+          },
+          required: ["file", "from", "to"],
+        },
+      },
+      {
+        name: "alps_set_doc",
+        description:
+          "Set or update the documentation of a descriptor in a JSON ALPS profile. " +
+          `Short single-line docs (<= ${INLINE_DOC_MAX_LENGTH} chars) are stored inline; ` +
+          "longer or multi-line docs are automatically written to an external Markdown " +
+          "file (alps/docs/<id>.md) and linked from the profile via doc.href. This keeps " +
+          "the profile compact, so feel free to write rich, detailed Markdown " +
+          "documentation describing the meaning of the state and related information.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON or XML)",
+            },
+            id: {
+              type: "string",
+              description: "Descriptor id",
+            },
+            doc: {
+              type: "string",
+              description: "Documentation text (Markdown welcome for external docs)",
+            },
+            placement: {
+              type: "string",
+              enum: ["auto", "inline", "external"],
+              description: "Storage placement (default: auto - the server decides by size)",
+            },
+          },
+          required: ["file", "id", "doc"],
+        },
+      },
     ],
   };
 });
@@ -179,6 +307,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return handleCrawlAndExtract(args);
     case "validate_openapi":
       return handleValidateOpenapi(args);
+    case "alps_overview":
+      return handleAlpsOverview(args);
+    case "alps_search":
+      return handleAlpsSearch(args);
+    case "alps_descriptor":
+      return handleAlpsDescriptor(args);
+    case "alps_paths":
+      return handleAlpsPaths(args);
+    case "alps_set_doc":
+      return handleAlpsSetDoc(args);
     default:
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -514,6 +652,275 @@ export async function handleValidateOpenapi(args: Record<string, unknown> | unde
 
     return {
       content: [{ type: "text", text: `Error running Spectral: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+const DOC_PREVIEW_LENGTH = 80;
+
+interface LoadedProfile {
+  document: AlpsDocument;
+  baseDir: string;
+}
+
+/**
+ * Read, parse, and resolve an ALPS profile from disk.
+ * Always reads fresh so edits between tool calls are visible.
+ */
+async function loadProfile(file: string): Promise<LoadedProfile> {
+  const absPath = path.resolve(file);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Profile file not found: ${file}`);
+  }
+  const content = fs.readFileSync(absPath, "utf-8");
+  const baseDir = path.dirname(absPath);
+  const parsed = parseAlpsAuto(content);
+  const resolver = new FileResolver(baseDir);
+  const document = await resolver.resolve(parsed);
+  return { document, baseDir };
+}
+
+/**
+ * Split the space-separated tag attribute into a list
+ */
+function descriptorTags(desc: AlpsDescriptor): string[] {
+  return (desc.tag || "").split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Short doc excerpt for search results; external docs show their href
+ */
+function docPreview(desc: AlpsDescriptor): string | undefined {
+  const text = docText(desc.doc);
+  if (!text) {
+    const href = typeof desc.doc === "object" ? desc.doc?.href : undefined;
+    return href ? `(external: ${href})` : undefined;
+  }
+  return text.length > DOC_PREVIEW_LENGTH ? `${text.slice(0, DOC_PREVIEW_LENGTH)}…` : text;
+}
+
+/**
+ * Compact descriptor summary returned by alps_search
+ */
+function summarize(desc: AlpsDescriptor) {
+  const tags = descriptorTags(desc);
+  const doc = docPreview(desc);
+  return {
+    id: desc.id,
+    type: desc.type || "semantic",
+    title: desc.title,
+    ...(desc.rt ? { rt: desc.rt } : {}),
+    ...(tags.length ? { tags } : {}),
+    ...(doc ? { doc } : {}),
+  };
+}
+
+/**
+ * Collect all descriptors (top-level and nested) in document order
+ */
+function allDescriptors(document: AlpsDocument): AlpsDescriptor[] {
+  const result: AlpsDescriptor[] = [];
+  walkDescriptors(document.alps.descriptor || [], (desc) => result.push(desc));
+  return result;
+}
+
+/**
+ * Tool result with pretty-printed JSON content
+ */
+function jsonResult(data: unknown) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+    isError: false,
+  };
+}
+
+export async function handleAlpsOverview(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+
+  if (!file) {
+    return {
+      content: [{ type: "text", text: "Error: file is required" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const { document } = await loadProfile(file);
+    const descriptors = allDescriptors(document);
+    const graph = extractGraph(document);
+    const tags = new Set<string>();
+    for (const desc of descriptors) {
+      descriptorTags(desc).forEach((tag) => tags.add(tag));
+    }
+    return jsonResult({
+      title: document.alps.title,
+      doc: docText(document.alps.doc) || undefined,
+      counts: {
+        descriptors: descriptors.length,
+        states: graph.states.length,
+        transitions: graph.transitions.length,
+      },
+      states: graph.states.map((s) => ({ id: s.id, title: s.title })),
+      transitions: graph.transitions.map((t) => ({
+        id: t.id,
+        type: t.type,
+        from: t.from,
+        to: t.to,
+      })),
+      tags: [...tags].sort(),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+export async function handleAlpsSearch(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const type = args?.type as string | undefined;
+  const tag = args?.tag as string | undefined;
+  const text = args?.text as string | undefined;
+
+  if (!file) {
+    return {
+      content: [{ type: "text", text: "Error: file is required" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const { document } = await loadProfile(file);
+    const descriptors = allDescriptors(document);
+    const needle = text?.toLowerCase();
+    const matches = descriptors.filter((desc) => {
+      if (!desc.id) {
+        return false;
+      }
+      if (type && (desc.type || "semantic") !== type) {
+        return false;
+      }
+      if (tag && !descriptorTags(desc).includes(tag)) {
+        return false;
+      }
+      if (needle) {
+        const haystack = `${desc.id} ${desc.title || ""} ${docText(desc.doc)}`.toLowerCase();
+        if (!haystack.includes(needle)) {
+          return false;
+        }
+      }
+      return true;
+    });
+    return jsonResult({ count: matches.length, descriptors: matches.map(summarize) });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+export async function handleAlpsDescriptor(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const id = args?.id as string | undefined;
+
+  if (!file || !id) {
+    return {
+      content: [{ type: "text", text: "Error: file and id are required" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const { document, baseDir } = await loadProfile(file);
+    const descriptors = document.alps.descriptor || [];
+    const descriptor = findDescriptorById(descriptors, id);
+    if (!descriptor) {
+      throw new Error(`Descriptor not found: ${id}`);
+    }
+    const graph = extractGraph(document);
+    return jsonResult({
+      descriptor,
+      doc: resolveDoc(baseDir, descriptor.doc),
+      containedBy: findContainers(id, descriptors),
+      outgoingTransitions: graph.transitions
+        .filter((t) => t.from.includes(id))
+        .map((t) => ({ id: t.id, type: t.type, to: t.to })),
+      incomingTransitions: graph.transitions
+        .filter((t) => t.to === id)
+        .map((t) => ({ id: t.id, type: t.type, from: t.from })),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+export async function handleAlpsPaths(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const from = args?.from as string | undefined;
+  const to = args?.to as string | undefined;
+  const maxPaths = args?.maxPaths as number | undefined;
+
+  if (!file || !from || !to) {
+    return {
+      content: [{ type: "text", text: "Error: file, from, and to are required" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const { document } = await loadProfile(file);
+    const graph = extractGraph(document);
+    const stateIds = new Set(graph.states.map((s) => s.id));
+    for (const state of [from, to]) {
+      if (!stateIds.has(state)) {
+        throw new Error(`Unknown state: ${state} (known states: ${[...stateIds].join(", ")})`);
+      }
+    }
+    const paths = findPaths(graph, from, to, maxPaths ?? 10);
+    return jsonResult({
+      from,
+      to,
+      count: paths.length,
+      paths: paths.map((p) => formatPath(from, p)),
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+export async function handleAlpsSetDoc(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const id = args?.id as string | undefined;
+  const doc = args?.doc as string | undefined;
+  const placement = args?.placement as "auto" | "inline" | "external" | undefined;
+
+  if (!file || !id || doc === undefined) {
+    return {
+      content: [{ type: "text", text: "Error: file, id, and doc are required" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const result = setDescriptorDoc(file, id, doc, placement ?? "auto");
+    return jsonResult(result);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
       isError: true,
     };
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -30,6 +30,7 @@ import { FileResolver } from "@alps-asd/app-state-diagram/resolver/index.js";
 import { extractGraph, findPaths, formatPath, findContainers, getDescriptorIdsByTags } from "@alps-asd/app-state-diagram/graph/index.js";
 import { addDescriptor, setDescriptorTags, renameDescriptor } from "./descriptor-store.js";
 import { setDescriptorDoc, resolveDoc, resolveSafeLocalPath, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
+import { loadTagVocabulary } from "./tag-vocabulary.js";
 
 // Crawler package is optional (not yet published)
 // import { AlpsCrawler } from "@alps-asd/crawler";
@@ -73,6 +74,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             alps_content: {
               type: "string",
               description: "ALPS profile XML or JSON content to validate",
+            },
+            vocabulary: {
+              type: "string",
+              description:
+                "Path to a tag vocabulary file (tags.html with tags as <dt> ids, see docs/tag-vocabulary.md). Tags used in the profile but not defined there are reported as W005 warnings.",
             },
           },
           required: ["alps_content"],
@@ -451,6 +457,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 export async function handleValidateAlps(args: Record<string, unknown> | undefined) {
   const alpsContent = args?.alps_content as string | undefined;
+  const vocabularyPath = args?.vocabulary as string | undefined;
 
   if (!alpsContent) {
     return {
@@ -463,6 +470,26 @@ export async function handleValidateAlps(args: Record<string, unknown> | undefin
     const document = parseAlpsAuto(alpsContent);
     const validator = new AlpsValidator();
     const result = validator.validate(document);
+
+    // Check used tags against the vocabulary file (docs/tag-vocabulary.md)
+    let unusedDefinedTags: string[] = [];
+    if (vocabularyPath) {
+      const vocabulary = loadTagVocabulary(vocabularyPath);
+      const usedTags = new Set<string>();
+      for (const desc of allDescriptors(document)) {
+        descriptorTags(desc).forEach((tag) => usedTags.add(tag));
+      }
+      for (const tag of [...usedTags].sort()) {
+        if (!vocabulary.has(tag)) {
+          result.warnings.push({
+            code: "W005",
+            severity: "warning",
+            message: `Unknown tag "${tag}" (not defined in ${vocabularyPath})`,
+          });
+        }
+      }
+      unusedDefinedTags = [...vocabulary.keys()].filter((tag) => !usedTags.has(tag)).sort();
+    }
 
     const lines: string[] = [];
 
@@ -485,6 +512,11 @@ export async function handleValidateAlps(args: Record<string, unknown> | undefin
       for (const w of result.warnings) {
         lines.push(`- [${w.code}] ${w.message}`);
       }
+      lines.push("");
+    }
+
+    if (unusedDefinedTags.length > 0) {
+      lines.push(`**Defined but unused tags** (${vocabularyPath}): ${unusedDefinedTags.join(", ")}`);
       lines.push("");
     }
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -28,7 +28,7 @@ import { dotToSvg } from "@alps-asd/app-state-diagram/generator/svg-generator.js
 import { generateMermaid } from "@alps-asd/app-state-diagram/generator/mermaid-generator.js";
 import { FileResolver } from "@alps-asd/app-state-diagram/resolver/index.js";
 import { extractGraph, findPaths, formatPath, findContainers, getDescriptorIdsByTags } from "@alps-asd/app-state-diagram/graph/index.js";
-import { addDescriptor } from "./descriptor-store.js";
+import { addDescriptor, setDescriptorTags } from "./descriptor-store.js";
 import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from "./doc-store.js";
 
 // Crawler package is optional (not yet published)
@@ -351,6 +351,35 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["file", "id"],
         },
       },
+      {
+        name: "alps_set_tags",
+        description:
+          "Add and/or remove tags in a descriptor's space-separated tag attribute in a JSON ALPS profile. Kept tags preserve their order, new tags are appended, and the tag property is removed when it becomes empty.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON only for writes)",
+            },
+            id: {
+              type: "string",
+              description: "Descriptor id",
+            },
+            add: {
+              type: "array",
+              items: { type: "string" },
+              description: "Tags to add (ones already present are ignored)",
+            },
+            remove: {
+              type: "array",
+              items: { type: "string" },
+              description: "Tags to remove (at least one of add/remove is required)",
+            },
+          },
+          required: ["file", "id"],
+        },
+      },
     ],
   };
 });
@@ -385,6 +414,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return handleAlpsSetDoc(args);
     case "alps_add_descriptor":
       return handleAlpsAddDescriptor(args);
+    case "alps_set_tags":
+      return handleAlpsSetTags(args);
     default:
       return {
         content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -478,6 +509,34 @@ export async function handleAlpsAddDescriptor(args: Record<string, unknown> | un
       docResult = setDescriptorDoc(file, id, doc, "auto");
     }
     return jsonResult({ ...result, ...(docResult ? { doc: docResult } : {}) });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Add and/or remove tags on a descriptor in a JSON profile
+ */
+export async function handleAlpsSetTags(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const id = args?.id as string | undefined;
+  if (!file || !id) {
+    return {
+      content: [{ type: "text", text: "Error: file and id are required" }],
+      isError: true,
+    };
+  }
+  try {
+    const result = setDescriptorTags(file, {
+      id,
+      add: args?.add as string[] | undefined,
+      remove: args?.remove as string[] | undefined,
+    });
+    return jsonResult(result);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -229,6 +229,30 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "alps_tags",
+        description:
+          "List the tags in use across an ALPS profile, grouped by facet (actor/flow/feature/src/page prefix, else domain) with usage counts. Given a vocabulary file (tags.html, see docs/tag-vocabulary.md), each tag is joined with its definition (defined, title).",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to the ALPS profile file (JSON or XML)",
+            },
+            vocabulary: {
+              type: "string",
+              description: "Path to a tag vocabulary file (tags.html with tags as <dt> ids, see docs/tag-vocabulary.md)",
+            },
+            format: {
+              type: "string",
+              enum: ["json", "markdown"],
+              description: "Output format: json (default) or a Markdown table (Tag, Facet, Count, Defined, Title) for direct display in chat",
+            },
+          },
+          required: ["file"],
+        },
+      },
+      {
         name: "alps_descriptor",
         description:
           "Get full details of one descriptor: definition, resolved documentation and rel=\"describedby\" links (local files are read and inlined; http(s) links are returned unresolved), containing states, and incoming/outgoing transitions.",
@@ -435,6 +459,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return handleAlpsOverview(args);
     case "alps_search":
       return handleAlpsSearch(args);
+    case "alps_tags":
+      return handleAlpsTags(args);
     case "alps_descriptor":
       return handleAlpsDescriptor(args);
     case "alps_paths":
@@ -1133,6 +1159,95 @@ export async function handleAlpsSearch(args: Record<string, unknown> | undefined
       return { content: [{ type: "text", text: descriptorsToMarkdownTable(matches.map(summarize)) }] };
     }
     return jsonResult({ count: matches.length, descriptors: matches.map(summarize) });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      content: [{ type: "text", text: `Error: ${errorMessage}` }],
+      isError: true,
+    };
+  }
+}
+
+/** Facet prefix registry (docs/tag-vocabulary.md); other tags are domain vocabulary */
+const FACET_PREFIXES = ["actor", "flow", "feature", "src", "page"];
+const FACET_ORDER = [...FACET_PREFIXES, "domain"];
+
+/**
+ * Classify a tag by its facet prefix (the part before the first "-")
+ */
+function tagFacet(tag: string): string {
+  const prefix = tag.split("-", 1)[0];
+  return tag.includes("-") && FACET_PREFIXES.includes(prefix) ? prefix : "domain";
+}
+
+interface TagUsage {
+  tag: string;
+  count: number;
+  defined?: boolean;
+  title?: string;
+}
+
+/**
+ * Render tag usage as a Markdown table for chat display
+ */
+function tagsToMarkdownTable(facets: Record<string, TagUsage[]>, hasVocabulary: boolean): string {
+  const escapeCell = (value: string): string => value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+  const lines = [
+    "| Tag | Facet | Count | Defined | Title |",
+    "| :-- | :-- | --: | :-- | :-- |",
+  ];
+  for (const [facet, usages] of Object.entries(facets)) {
+    for (const usage of usages) {
+      const defined = hasVocabulary ? (usage.defined ? "yes" : "no") : "";
+      lines.push(
+        `| ${escapeCell(usage.tag)} | ${facet} | ${usage.count} | ${defined} | ${escapeCell(usage.title || "")} |`
+      );
+    }
+  }
+  return lines.length === 2 ? "No tags in use." : lines.join("\n");
+}
+
+export async function handleAlpsTags(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+  const vocabularyPath = args?.vocabulary as string | undefined;
+
+  if (!file) {
+    return {
+      content: [{ type: "text", text: "Error: file is required" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const { document } = await loadProfile(file);
+    const vocabulary = vocabularyPath ? loadTagVocabulary(vocabularyPath) : undefined;
+    const counts = new Map<string, number>();
+    for (const desc of allDescriptors(document)) {
+      for (const tag of descriptorTags(desc)) {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      }
+    }
+    const grouped: Record<string, TagUsage[]> = {};
+    for (const tag of [...counts.keys()].sort()) {
+      const usage: TagUsage = { tag, count: counts.get(tag)! };
+      if (vocabulary) {
+        usage.defined = vocabulary.has(tag);
+        if (usage.defined) {
+          usage.title = vocabulary.get(tag);
+        }
+      }
+      (grouped[tagFacet(tag)] ??= []).push(usage);
+    }
+    const facets: Record<string, TagUsage[]> = {};
+    for (const facet of FACET_ORDER) {
+      if (grouped[facet]) {
+        facets[facet] = grouped[facet];
+      }
+    }
+    if ((args?.format as string | undefined) === "markdown") {
+      return { content: [{ type: "text", text: tagsToMarkdownTable(facets, vocabulary !== undefined) }] };
+    }
+    return jsonResult({ count: counts.size, facets });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -100,7 +100,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             tag: {
               type: "string",
-              description: "Filter the diagram to descriptors with these tags (space or comma separated). Shows the induced subgraph: tagged nodes plus endpoints of tagged transitions.",
+              description: "Filter the diagram to descriptors with these tags (space- or comma-separated). Shows the induced subgraph: tagged nodes plus endpoints of tagged transitions.",
             },
             output: {
               type: "string",
@@ -125,7 +125,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             tag: {
               type: "string",
-              description: "Filter the diagram to descriptors with these tags (space or comma separated). Shows the induced subgraph: tagged nodes plus endpoints of tagged transitions.",
+              description: "Filter the diagram to descriptors with these tags (space- or comma-separated). Shows the induced subgraph: tagged nodes plus endpoints of tagged transitions.",
             },
           },
         },
@@ -213,7 +213,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             tag: {
               type: "string",
-              description: "Filter by tag(s), space or comma separated (OR match against the descriptor's space-separated tags)",
+              description: "Filter by tag(s), space- or comma-separated (OR match against the descriptor's space-separated tags)",
             },
             text: {
               type: "string",
@@ -577,6 +577,9 @@ export async function handleAlpsAddDescriptor(args: Record<string, unknown> | un
     };
   }
   try {
+    // Snapshot for rollback so a doc failure cannot leave a partial update
+    const absPath = path.resolve(file);
+    const original = fs.existsSync(absPath) ? fs.readFileSync(absPath, "utf-8") : null;
     const result = addDescriptor(file, {
       id,
       type: args?.type as "semantic" | "safe" | "unsafe" | "idempotent" | undefined,
@@ -589,7 +592,14 @@ export async function handleAlpsAddDescriptor(args: Record<string, unknown> | un
     const doc = args?.doc as string | undefined;
     let docResult: unknown;
     if (doc) {
-      docResult = setDescriptorDoc(file, id, doc, "auto");
+      try {
+        docResult = setDescriptorDoc(file, id, doc, "auto");
+      } catch (docError) {
+        if (original !== null) {
+          fs.writeFileSync(absPath, original, "utf-8");
+        }
+        throw docError;
+      }
     }
     return jsonResult({ ...result, ...(docResult ? { doc: docResult } : {}) });
   } catch (error) {
@@ -1346,7 +1356,9 @@ export async function handleAlpsPaths(args: Record<string, unknown> | undefined)
         throw new Error(`Unknown state: ${state} (known states: ${[...stateIds].join(", ")})`);
       }
     }
-    const paths = findPaths(graph, from, to, maxPaths ?? 10);
+    // Clamp to keep enumeration bounded regardless of caller input
+    const boundedMaxPaths = Math.min(50, Math.max(1, Math.trunc(maxPaths ?? 10) || 10));
+    const paths = findPaths(graph, from, to, boundedMaxPaths);
     return jsonResult({
       from,
       to,

--- a/packages/mcp/src/profile-tools.test.ts
+++ b/packages/mcp/src/profile-tools.test.ts
@@ -229,6 +229,54 @@ describe('handleAlpsDescriptor', () => {
     });
   });
 
+  const writeWithLink = (link: unknown) => {
+    const profile = JSON.parse(JSON.stringify(PROFILE));
+    profile.alps.descriptor[2].link = link;
+    fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2) + '\n');
+  };
+
+  it('should resolve local describedby links', async () => {
+    fs.mkdirSync(path.join(dir, 'alps-doc'));
+    fs.writeFileSync(path.join(dir, 'alps-doc', 'cart.md'), '# Cart\n\nEntity details.\n');
+    writeWithLink({ rel: 'describedby', href: 'alps-doc/cart.md' });
+
+    const result = await handleAlpsDescriptor({ file: profilePath, id: 'Cart' });
+
+    expect(result.isError).toBe(false);
+    expect(parseResult(result).describedBy).toEqual([
+      { rel: 'describedby', href: 'alps-doc/cart.md', text: '# Cart\n\nEntity details.\n' },
+    ]);
+  });
+
+  it('should return http describedby links unresolved and skip other rels', async () => {
+    writeWithLink([
+      { rel: 'describedby', href: 'https://example.com/cart.md' },
+      { rel: 'help', href: 'https://example.com/help' },
+    ]);
+
+    const result = await handleAlpsDescriptor({ file: profilePath, id: 'Cart' });
+
+    expect(parseResult(result).describedBy).toEqual([
+      { rel: 'describedby', href: 'https://example.com/cart.md' },
+    ]);
+  });
+
+  it('should not read describedby links escaping the profile directory', async () => {
+    const outside = path.join(path.dirname(dir), `${path.basename(dir)}-secret.md`);
+    fs.writeFileSync(outside, 'secret');
+    try {
+      writeWithLink({ rel: 'describedby', href: `../${path.basename(outside)}` });
+
+      const result = await handleAlpsDescriptor({ file: profilePath, id: 'Cart' });
+
+      expect(parseResult(result).describedBy).toEqual([
+        { rel: 'describedby', href: `../${path.basename(outside)}` },
+      ]);
+    } finally {
+      fs.rmSync(outside, { force: true });
+    }
+  });
+
   it('should return error for unknown descriptor ids', async () => {
     const result = await handleAlpsDescriptor({ file: profilePath, id: 'Nope' });
 

--- a/packages/mcp/src/profile-tools.test.ts
+++ b/packages/mcp/src/profile-tools.test.ts
@@ -1,0 +1,332 @@
+/**
+ * MCP Profile Tool Handler Tests
+ *
+ * Tests the alps_overview, alps_search, alps_descriptor, alps_paths, and
+ * alps_set_doc handlers against real temp profile files (no fs mocking,
+ * since alps_set_doc writes profiles and external doc files to disk).
+ */
+
+const {
+  handleAlpsOverview,
+  handleAlpsSearch,
+  handleAlpsDescriptor,
+  handleAlpsPaths,
+  handleAlpsSetDoc,
+} = require('./index');
+const { DOC_DIR } = require('./doc-store');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const PROFILE = {
+  alps: {
+    title: 'Store',
+    doc: 'Online store profile',
+    descriptor: [
+      {
+        id: 'Home',
+        type: 'semantic',
+        tag: 'nav',
+        descriptor: [{ href: '#goCatalog' }, { href: '#goCart' }],
+      },
+      {
+        id: 'Catalog',
+        type: 'semantic',
+        tag: 'catalog',
+        doc: 'Product catalog page',
+        descriptor: [{ href: '#goHome' }, { href: '#doAddToCart' }],
+      },
+      { id: 'Cart', type: 'semantic', tag: 'cart checkout', descriptor: [{ href: '#goCheckout' }] },
+      { id: 'Checkout', type: 'semantic', tag: 'checkout' },
+      { id: 'goCatalog', type: 'safe', rt: '#Catalog', tag: 'nav' },
+      { id: 'goCart', type: 'safe', rt: '#Cart', tag: 'nav' },
+      { id: 'goHome', type: 'safe', rt: '#Home', tag: 'nav' },
+      { id: 'doAddToCart', type: 'unsafe', rt: '#Cart', tag: 'cart' },
+      { id: 'goCheckout', type: 'safe', rt: '#Checkout', tag: 'checkout' },
+      { id: 'price', type: 'semantic' },
+    ],
+  },
+};
+
+let dir: string;
+let profilePath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'profile-tools-'));
+  profilePath = path.join(dir, 'profile.json');
+  fs.writeFileSync(profilePath, JSON.stringify(PROFILE, null, 2) + '\n');
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const parseResult = (result: { content: { text: string }[] }) =>
+  JSON.parse(result.content[0].text);
+
+describe('handleAlpsOverview', () => {
+  it('should summarize states, transitions, and tags', async () => {
+    const result = await handleAlpsOverview({ file: profilePath });
+
+    expect(result.isError).toBe(false);
+    const overview = parseResult(result);
+    expect(overview.title).toBe('Store');
+    expect(overview.doc).toBe('Online store profile');
+    expect(overview.counts).toEqual({ descriptors: 15, states: 4, transitions: 5 });
+    expect(overview.states.map((s: { id: string }) => s.id).sort()).toEqual([
+      'Cart',
+      'Catalog',
+      'Checkout',
+      'Home',
+    ]);
+    expect(overview.transitions).toContainEqual({
+      id: 'doAddToCart',
+      type: 'unsafe',
+      from: ['Catalog'],
+      to: 'Cart',
+    });
+    expect(overview.tags).toEqual(['cart', 'catalog', 'checkout', 'nav']);
+  });
+
+  it('should read XML profiles', async () => {
+    const xmlPath = path.join(dir, 'profile.xml');
+    fs.writeFileSync(
+      xmlPath,
+      `<?xml version="1.0"?>
+<alps>
+  <descriptor id="Home" type="semantic">
+    <descriptor href="#goHome"/>
+  </descriptor>
+  <descriptor id="goHome" type="safe" rt="#Home"/>
+</alps>`
+    );
+
+    const result = await handleAlpsOverview({ file: xmlPath });
+
+    expect(result.isError).toBe(false);
+    expect(parseResult(result).states.map((s: { id: string }) => s.id)).toEqual(['Home']);
+  });
+
+  it('should return error when file is missing', async () => {
+    const result = await handleAlpsOverview({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: file is required');
+  });
+
+  it('should return error when args is undefined', async () => {
+    const result = await handleAlpsOverview(undefined);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: file is required');
+  });
+
+  it('should return error when the profile does not exist', async () => {
+    const result = await handleAlpsOverview({ file: path.join(dir, 'none.json') });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: Profile file not found');
+  });
+});
+
+describe('handleAlpsSearch', () => {
+  it('should filter by type', async () => {
+    const result = await handleAlpsSearch({ file: profilePath, type: 'unsafe' });
+
+    expect(result.isError).toBe(false);
+    const search = parseResult(result);
+    expect(search.count).toBe(1);
+    expect(search.descriptors[0]).toMatchObject({ id: 'doAddToCart', type: 'unsafe' });
+  });
+
+  it('should filter by tag', async () => {
+    const result = await handleAlpsSearch({ file: profilePath, tag: 'cart' });
+
+    expect(parseResult(result).descriptors.map((d: { id: string }) => d.id)).toEqual([
+      'Cart',
+      'doAddToCart',
+    ]);
+  });
+
+  it('should search text in id, title, and doc', async () => {
+    const result = await handleAlpsSearch({ file: profilePath, text: 'catalog' });
+
+    expect(parseResult(result).descriptors.map((d: { id: string }) => d.id)).toEqual([
+      'Catalog',
+      'goCatalog',
+    ]);
+  });
+
+  it('should combine filters', async () => {
+    const result = await handleAlpsSearch({ file: profilePath, type: 'safe', tag: 'nav' });
+
+    expect(parseResult(result).descriptors.map((d: { id: string }) => d.id)).toEqual([
+      'goCatalog',
+      'goCart',
+      'goHome',
+    ]);
+  });
+
+  it('should resolve external href references', async () => {
+    fs.writeFileSync(
+      path.join(dir, 'shared.json'),
+      JSON.stringify({
+        alps: { descriptor: [{ id: 'address', type: 'semantic', title: 'Address' }] },
+      })
+    );
+    const profile = {
+      alps: { descriptor: [{ href: 'shared.json#address' }] },
+    };
+    fs.writeFileSync(profilePath, JSON.stringify(profile));
+
+    const result = await handleAlpsSearch({ file: profilePath, text: 'address' });
+
+    expect(parseResult(result).descriptors).toEqual([
+      { id: 'address', type: 'semantic', title: 'Address' },
+    ]);
+  });
+
+  it('should return error when file is missing', async () => {
+    const result = await handleAlpsSearch({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: file is required');
+  });
+});
+
+describe('handleAlpsDescriptor', () => {
+  it('should return descriptor details with containers and transitions', async () => {
+    const result = await handleAlpsDescriptor({ file: profilePath, id: 'Catalog' });
+
+    expect(result.isError).toBe(false);
+    const details = parseResult(result);
+    expect(details.descriptor.id).toBe('Catalog');
+    expect(details.doc).toEqual({ text: 'Product catalog page' });
+    expect(details.containedBy).toEqual([]);
+    expect(details.outgoingTransitions).toEqual([
+      { id: 'goHome', type: 'safe', to: 'Home' },
+      { id: 'doAddToCart', type: 'unsafe', to: 'Cart' },
+    ]);
+    expect(details.incomingTransitions).toEqual([{ id: 'goCatalog', type: 'safe', from: ['Home'] }]);
+  });
+
+  it('should report containing states for transitions', async () => {
+    const result = await handleAlpsDescriptor({ file: profilePath, id: 'goCheckout' });
+
+    expect(parseResult(result).containedBy).toEqual(['Cart']);
+  });
+
+  it('should resolve external doc files written by alps_set_doc', async () => {
+    const doc = '# Catalog\n\nDetailed catalog documentation.';
+    await handleAlpsSetDoc({ file: profilePath, id: 'Catalog', doc });
+
+    const result = await handleAlpsDescriptor({ file: profilePath, id: 'Catalog' });
+
+    expect(parseResult(result).doc).toEqual({
+      text: doc + '\n',
+      href: `${DOC_DIR}/Catalog.md`,
+      format: 'markdown',
+    });
+  });
+
+  it('should return error for unknown descriptor ids', async () => {
+    const result = await handleAlpsDescriptor({ file: profilePath, id: 'Nope' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: Descriptor not found: Nope');
+  });
+
+  it('should return error when file or id is missing', async () => {
+    const result = await handleAlpsDescriptor({ file: profilePath });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: file and id are required');
+  });
+});
+
+describe('handleAlpsPaths', () => {
+  it('should enumerate paths between states', async () => {
+    const result = await handleAlpsPaths({ file: profilePath, from: 'Home', to: 'Checkout' });
+
+    expect(result.isError).toBe(false);
+    const paths = parseResult(result);
+    expect(paths.count).toBe(2);
+    expect(paths.paths.sort()).toEqual([
+      'Home --goCart(safe)--> Cart --goCheckout(safe)--> Checkout',
+      'Home --goCatalog(safe)--> Catalog --doAddToCart(unsafe)--> Cart --goCheckout(safe)--> Checkout',
+    ]);
+  });
+
+  it('should respect maxPaths', async () => {
+    const result = await handleAlpsPaths({
+      file: profilePath,
+      from: 'Home',
+      to: 'Checkout',
+      maxPaths: 1,
+    });
+
+    expect(parseResult(result).count).toBe(1);
+  });
+
+  it('should return error for unknown states', async () => {
+    const result = await handleAlpsPaths({ file: profilePath, from: 'Nope', to: 'Checkout' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: Unknown state: Nope');
+  });
+
+  it('should return error when file, from, or to is missing', async () => {
+    const result = await handleAlpsPaths({ file: profilePath, from: 'Home' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: file, from, and to are required');
+  });
+});
+
+describe('handleAlpsSetDoc', () => {
+  it('should store short docs inline', async () => {
+    const result = await handleAlpsSetDoc({ file: profilePath, id: 'Home', doc: 'Entry point.' });
+
+    expect(result.isError).toBe(false);
+    expect(parseResult(result)).toEqual({ id: 'Home', placement: 'inline' });
+    const profile = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+    expect(profile.alps.descriptor[0].doc).toBe('Entry point.');
+  });
+
+  it('should externalize multi-line docs to alps/docs', async () => {
+    const doc = '# Home\n\nDetailed documentation.';
+    const result = await handleAlpsSetDoc({ file: profilePath, id: 'Home', doc });
+
+    expect(parseResult(result)).toEqual({
+      id: 'Home',
+      placement: 'external',
+      docFile: `${DOC_DIR}/Home.md`,
+    });
+    expect(fs.readFileSync(path.join(dir, DOC_DIR, 'Home.md'), 'utf-8')).toBe(doc + '\n');
+  });
+
+  it('should honor explicit placement', async () => {
+    const result = await handleAlpsSetDoc({
+      file: profilePath,
+      id: 'Home',
+      doc: 'Short.',
+      placement: 'external',
+    });
+
+    expect(parseResult(result).placement).toBe('external');
+  });
+
+  it('should return error for unknown descriptor ids', async () => {
+    const result = await handleAlpsSetDoc({ file: profilePath, id: 'Nope', doc: 'doc' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: Descriptor not found: Nope');
+  });
+
+  it('should return error when file, id, or doc is missing', async () => {
+    const result = await handleAlpsSetDoc({ file: profilePath, id: 'Home' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error: file, id, and doc are required');
+  });
+});

--- a/packages/mcp/src/tag-filter.test.ts
+++ b/packages/mcp/src/tag-filter.test.ts
@@ -80,3 +80,43 @@ describe("alps_search markdown format", () => {
     }
   });
 });
+
+describe("alps_add_descriptor rollback and alps_paths clamping", () => {
+  it("restores the profile when the doc write fails after the add", async () => {
+    const { handleAlpsAddDescriptor } = await import("./index.js");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alps-rollback-"));
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "alps-rollback-out-"));
+    const file = path.join(dir, "profile.json");
+    const original = JSON.stringify({ alps: { descriptor: [] } }, null, 2) + "\n";
+    try {
+      fs.writeFileSync(file, original);
+      fs.symlinkSync(outside, path.join(dir, "alps")); // makes alps/docs writes unsafe
+      const result = await handleAlpsAddDescriptor({
+        file,
+        id: "person",
+        doc: "line1\nline2 forces external placement",
+      });
+      expect(result.isError).toBe(true);
+      expect(fs.readFileSync(file, "utf-8")).toBe(original); // unchanged
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("clamps out-of-range maxPaths instead of failing", async () => {
+    const { handleAlpsPaths } = await import("./index.js");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alps-paths-"));
+    const file = path.join(dir, "profile.json");
+    try {
+      fs.writeFileSync(file, PROFILE);
+      for (const maxPaths of [-5, 0, 100000, 2.7]) {
+        const result = await handleAlpsPaths({ file, from: "Home", to: "Cart", maxPaths });
+        expect(result.isError).not.toBe(true);
+        expect(JSON.parse((result.content[0] as { text: string }).text).count).toBeGreaterThanOrEqual(1);
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp/src/tag-filter.test.ts
+++ b/packages/mcp/src/tag-filter.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the tag filter and file output options of the diagram tools.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { handleAlps2Mermaid, handleAlps2Svg } from "./index.js";
+
+const PROFILE = JSON.stringify({
+  alps: {
+    descriptor: [
+      { id: "Home", type: "semantic", descriptor: [{ href: "#goCart" }, { href: "#goAdmin" }] },
+      { id: "Cart", type: "semantic" },
+      { id: "AdminTop", type: "semantic" },
+      { id: "goCart", type: "safe", rt: "#Cart", tag: "cart" },
+      { id: "goAdmin", type: "safe", rt: "#AdminTop", tag: "admin" },
+    ],
+  },
+});
+
+describe("alps2mermaid tag filter", () => {
+  it("renders only the tagged slice", async () => {
+    const result = await handleAlps2Mermaid({ alps_content: PROFILE, tag: "cart" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("Home --> Cart");
+    expect(text).not.toContain("AdminTop");
+  });
+
+  it("accepts comma or space separated tags", async () => {
+    const result = await handleAlps2Mermaid({ alps_content: PROFILE, tag: "cart, admin" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("Cart");
+    expect(text).toContain("AdminTop");
+  });
+
+  it("errors on tags matching nothing", async () => {
+    const result = await handleAlps2Mermaid({ alps_content: PROFILE, tag: "nope" });
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain("No descriptors match");
+  });
+});
+
+describe("alps2svg tag filter and output", () => {
+  it("writes the filtered SVG to a file and returns the path", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alps-svg-"));
+    const outPath = path.join(dir, "cart.svg");
+    try {
+      const result = await handleAlps2Svg({ alps_content: PROFILE, tag: "cart", output: outPath });
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain(outPath);
+      const svg = fs.readFileSync(outPath, "utf-8");
+      expect(svg).toContain("<svg");
+      expect(svg).toContain("Cart");
+      expect(svg).not.toContain("AdminTop");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("alps_search markdown format", () => {
+  it("renders a Markdown table", async () => {
+    const { handleAlpsSearch } = await import("./index.js");
+    const dir = (await import("os")).tmpdir();
+    const file = (await import("path")).join(dir, `alps-table-${Date.now()}.json`);
+    fs.writeFileSync(file, PROFILE);
+    try {
+      const result = await handleAlpsSearch({ file, tag: "cart", format: "markdown" });
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain("| ID | Type | Title | Tags | Doc |");
+      expect(text).toContain("| goCart | safe |");
+      expect(text).not.toContain("goAdmin");
+
+      const multi = await handleAlpsSearch({ file, tag: "cart, admin", format: "markdown" });
+      const multiText = (multi.content[0] as { text: string }).text;
+      expect(multiText).toContain("goCart");
+      expect(multiText).toContain("goAdmin");
+    } finally {
+      fs.rmSync(file, { force: true });
+    }
+  });
+});

--- a/packages/mcp/src/tag-vocabulary.test.ts
+++ b/packages/mcp/src/tag-vocabulary.test.ts
@@ -59,6 +59,12 @@ describe("parseTagVocabulary", () => {
     expect(vocabulary.get("checkout")).toBe("Checkout");
     expect(vocabulary.has("top")).toBe(false);
   });
+
+  it("ignores dt elements without id attributes", () => {
+    const vocabulary = parseTagVocabulary("<dl><dt>No id</dt><dt id=\"known\">Known</dt></dl>");
+
+    expect([...vocabulary.entries()]).toEqual([["known", "Known"]]);
+  });
 });
 
 describe("validate_alps vocabulary option", () => {

--- a/packages/mcp/src/tag-vocabulary.test.ts
+++ b/packages/mcp/src/tag-vocabulary.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tag vocabulary tests
+ *
+ * Covers tags.html parsing (docs/tag-vocabulary.md convention) and the
+ * vocabulary option of validate_alps, against real temp files.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { handleValidateAlps } from "./index.js";
+import { parseTagVocabulary } from "./tag-vocabulary.js";
+
+const VOCABULARY_HTML = `<!DOCTYPE html>
+<html lang="en">
+<body>
+  <h1 id="top">Store Tag Vocabulary</h1>
+  <section data-facet="flow">
+    <dl>
+      <dt id="flow-customer-purchase" data-actor="customer"
+          data-spans="feature-browse feature-purchase">Customer <em>purchase</em></dt>
+      <dd>A customer completes an order.
+        <p data-role="goal">Order recorded.</p>
+      </dd>
+    </dl>
+  </section>
+  <section data-facet="domain">
+    <dl>
+      <dt id='checkout'>Checkout</dt><dd>Order placement vocabulary.</dd>
+      <dt id="catalog">Catalog</dt><dd>Product vocabulary.</dd>
+    </dl>
+  </section>
+</body>
+</html>
+`;
+
+const PROFILE = JSON.stringify({
+  alps: {
+    title: "Store",
+    descriptor: [
+      {
+        id: "Cart",
+        type: "semantic",
+        title: "Cart",
+        tag: "checkout flow-customer-purchase",
+        descriptor: [{ id: "goCheckout", type: "safe", rt: "#Checkout", title: "Go", tag: "checkout" }],
+      },
+      { id: "Checkout", type: "semantic", title: "Checkout", tag: "checkout" },
+    ],
+  },
+});
+
+describe("parseTagVocabulary", () => {
+  it("extracts dt ids with markup-stripped titles, ignoring ids on other elements", () => {
+    const vocabulary = parseTagVocabulary(VOCABULARY_HTML);
+
+    expect([...vocabulary.keys()].sort()).toEqual(["catalog", "checkout", "flow-customer-purchase"]);
+    expect(vocabulary.get("flow-customer-purchase")).toBe("Customer purchase");
+    expect(vocabulary.get("checkout")).toBe("Checkout");
+    expect(vocabulary.has("top")).toBe(false);
+  });
+});
+
+describe("validate_alps vocabulary option", () => {
+  let dir: string;
+  let vocabularyPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "tag-vocabulary-"));
+    vocabularyPath = path.join(dir, "tags.html");
+    fs.writeFileSync(vocabularyPath, VOCABULARY_HTML);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("accepts profiles whose tags are all defined", async () => {
+    const result = await handleValidateAlps({ alps_content: PROFILE, vocabulary: vocabularyPath });
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain("✅ ALPS Validation SUCCESSFUL");
+    expect(result.content[0].text).not.toContain("W005");
+  });
+
+  it("warns W005 for each used tag missing from the vocabulary", async () => {
+    const profile = JSON.stringify({
+      alps: {
+        title: "Store",
+        descriptor: [
+          { id: "Cart", type: "semantic", title: "Cart", tag: "checkout flow-purchace" },
+          { id: "price", type: "semantic", title: "Price", tag: "pricing" },
+        ],
+      },
+    });
+
+    const result = await handleValidateAlps({ alps_content: profile, vocabulary: vocabularyPath });
+
+    expect(result.isError).toBe(false);
+    const text = result.content[0].text;
+    expect(text).toContain(`- [W005] Unknown tag "flow-purchace" (not defined in ${vocabularyPath})`);
+    expect(text).toContain(`- [W005] Unknown tag "pricing" (not defined in ${vocabularyPath})`);
+    expect(text).not.toContain('Unknown tag "checkout"');
+  });
+
+  it("lists defined but unused tags informationally", async () => {
+    const result = await handleValidateAlps({ alps_content: PROFILE, vocabulary: vocabularyPath });
+
+    expect(result.content[0].text).toContain(
+      `**Defined but unused tags** (${vocabularyPath}): catalog`
+    );
+  });
+
+  it("returns error when the vocabulary file does not exist", async () => {
+    const missing = path.join(dir, "none.html");
+
+    const result = await handleValidateAlps({ alps_content: PROFILE, vocabulary: missing });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(`Error: Vocabulary file not found: ${missing}`);
+  });
+
+  it("does not check tags when vocabulary is omitted", async () => {
+    const result = await handleValidateAlps({ alps_content: PROFILE });
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).not.toContain("W005");
+    expect(result.content[0].text).not.toContain("unused");
+  });
+});

--- a/packages/mcp/src/tag-vocabulary.test.ts
+++ b/packages/mcp/src/tag-vocabulary.test.ts
@@ -1,13 +1,14 @@
 /**
  * Tag vocabulary tests
  *
- * Covers tags.html parsing (docs/tag-vocabulary.md convention) and the
- * vocabulary option of validate_alps, against real temp files.
+ * Covers tags.html parsing (docs/tag-vocabulary.md convention), the
+ * vocabulary option of validate_alps, and the alps_tags tool, against
+ * real temp files.
  */
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { handleValidateAlps } from "./index.js";
+import { handleAlpsTags, handleValidateAlps } from "./index.js";
 import { parseTagVocabulary } from "./tag-vocabulary.js";
 
 const VOCABULARY_HTML = `<!DOCTYPE html>
@@ -125,5 +126,111 @@ describe("validate_alps vocabulary option", () => {
     expect(result.isError).toBe(false);
     expect(result.content[0].text).not.toContain("W005");
     expect(result.content[0].text).not.toContain("unused");
+  });
+});
+
+describe("handleAlpsTags", () => {
+  const TAGS_PROFILE = JSON.stringify({
+    alps: {
+      title: "Store",
+      descriptor: [
+        {
+          id: "Cart",
+          type: "semantic",
+          title: "Cart",
+          tag: "checkout flow-customer-purchase actor-customer",
+        },
+        { id: "Checkout", type: "semantic", title: "Checkout", tag: "checkout page-edit" },
+        {
+          id: "goCheckout",
+          type: "safe",
+          rt: "#Checkout",
+          title: "Go",
+          tag: "checkout flow-customer-purchase",
+        },
+        { id: "price", type: "semantic", title: "Price", tag: "src-entity" },
+        { id: "feature", type: "semantic", title: "Bare", tag: "feature" },
+      ],
+    },
+  });
+
+  let dir: string;
+  let profilePath: string;
+  let vocabularyPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "alps-tags-"));
+    profilePath = path.join(dir, "profile.json");
+    vocabularyPath = path.join(dir, "tags.html");
+    fs.writeFileSync(profilePath, TAGS_PROFILE);
+    fs.writeFileSync(vocabularyPath, VOCABULARY_HTML);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const parseResult = (result: { content: { text: string }[] }) =>
+    JSON.parse(result.content[0].text);
+
+  it("groups tags by facet with usage counts", async () => {
+    const result = await handleAlpsTags({ file: profilePath });
+
+    expect(result.isError).toBe(false);
+    const tags = parseResult(result);
+    expect(tags.count).toBe(6);
+    expect(Object.keys(tags.facets)).toEqual(["actor", "flow", "src", "page", "domain"]);
+    expect(tags.facets.flow).toEqual([{ tag: "flow-customer-purchase", count: 2 }]);
+    expect(tags.facets.src).toEqual([{ tag: "src-entity", count: 1 }]);
+    // Unprefixed tags are domain vocabulary, even when they spell a facet name
+    expect(tags.facets.domain).toEqual([
+      { tag: "checkout", count: 3 },
+      { tag: "feature", count: 1 },
+    ]);
+  });
+
+  it("joins tags with their vocabulary definitions", async () => {
+    const result = await handleAlpsTags({ file: profilePath, vocabulary: vocabularyPath });
+
+    const tags = parseResult(result);
+    expect(tags.facets.flow).toEqual([
+      { tag: "flow-customer-purchase", count: 2, defined: true, title: "Customer purchase" },
+    ]);
+    expect(tags.facets.actor).toEqual([{ tag: "actor-customer", count: 1, defined: false }]);
+    expect(tags.facets.domain).toContainEqual({
+      tag: "checkout",
+      count: 3,
+      defined: true,
+      title: "Checkout",
+    });
+  });
+
+  it("renders a Markdown table", async () => {
+    const result = await handleAlpsTags({
+      file: profilePath,
+      vocabulary: vocabularyPath,
+      format: "markdown",
+    });
+
+    const text = result.content[0].text;
+    expect(text).toContain("| Tag | Facet | Count | Defined | Title |");
+    expect(text).toContain("| checkout | domain | 3 | yes | Checkout |");
+    expect(text).toContain("| actor-customer | actor | 1 | no |  |");
+  });
+
+  it("returns error when the vocabulary file does not exist", async () => {
+    const missing = path.join(dir, "none.html");
+
+    const result = await handleAlpsTags({ file: profilePath, vocabulary: missing });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(`Error: Vocabulary file not found: ${missing}`);
+  });
+
+  it("returns error when file is missing", async () => {
+    const result = await handleAlpsTags({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Error: file is required");
   });
 });

--- a/packages/mcp/src/tag-vocabulary.ts
+++ b/packages/mcp/src/tag-vocabulary.ts
@@ -1,0 +1,49 @@
+/**
+ * Tag vocabulary - tags.html parsing per the ALPS Tag Vocabulary convention
+ * (docs/tag-vocabulary.md)
+ *
+ * A vocabulary file defines each tag as the id of a <dt> element:
+ * <dt id="flow-customer-purchase">Customer purchase</dt>. Extraction is a
+ * light regex pass rather than full HTML parsing, so tag ids MUST be on
+ * <dt> elements; ids on any other element are ignored.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+/** Defined tags: tag value -> human-readable title (the dt text content) */
+export type TagVocabulary = Map<string, string>;
+
+const DT_PATTERN = /<dt\b([^>]*)>([\s\S]*?)<\/dt>/gi;
+const ID_PATTERN = /\bid\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+
+/**
+ * Extract the defined tags from vocabulary HTML: all id="..." values on
+ * <dt> elements, mapped to the element's text content
+ */
+export function parseTagVocabulary(html: string): TagVocabulary {
+  const vocabulary: TagVocabulary = new Map();
+  for (const match of html.matchAll(DT_PATTERN)) {
+    const idMatch = match[1].match(ID_PATTERN);
+    const id = idMatch?.[1] ?? idMatch?.[2];
+    if (!id) {
+      continue;
+    }
+    const title = match[2].replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+    vocabulary.set(id, title);
+  }
+  return vocabulary;
+}
+
+/**
+ * Read and parse a vocabulary file. The path is user-supplied input like
+ * the profile path itself, so it is resolved as given (not sandboxed to
+ * the profile directory).
+ */
+export function loadTagVocabulary(vocabularyPath: string): TagVocabulary {
+  const absPath = path.resolve(vocabularyPath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Vocabulary file not found: ${vocabularyPath}`);
+  }
+  return parseTagVocabulary(fs.readFileSync(absPath, "utf-8"));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag-filtered diagram exports (Mermaid/SVG) with option to save SVG to disk.
  * Nine new ALPS tools: overview, search (JSON or markdown table), tags, descriptor detail, paths, set-doc (auto/inline/external), add-descriptor, set-tags, rename-descriptor.
  * Descriptor doc externalization: long/multiline docs written to profile-local markdown files; safe-path checks.

* **Documentation**
  * Expanded AI integration and MCP tool docs; new tag-vocabulary guide with examples.

* **Tests**
  * Broad new test coverage for tools, graph utilities, parser, doc/descriptor stores, and diagram generators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->