### PR TITLE
Add profile share URLs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,7 @@
             <option value="diagram">Diagram</option>
             <option value="preview">Preview</option>
         </select>
+        <button id="shareUrlButton">Share URL</button>
         <details class="download-menu">
             <summary id="downloadBtn">Download</summary>
             <div class="download-options">
@@ -48,6 +49,6 @@
     </div>
 </div>
 <div id="debug"></div>
-<script type="module" src="js/scripts.js?v=tag-filter-20260606b"></script>
+<script type="module" src="js/scripts.js?v=profile-share-url-20260611"></script>
 </body>
 </html>

--- a/docs/js/scripts.js
+++ b/docs/js/scripts.js
@@ -68,6 +68,7 @@ class AlpsEditor {
             this.setupDragAndDrop();
             this.setupCompleteHref();
             this.setupDownloadButton();
+            this.setupShareUrlButton();
             this.setupAdapterSelector();
             this.setupViewModeSelector();
             this.setupDiagramClickHandler();
@@ -244,8 +245,9 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
 
 </alps>`;
 
-            // Use pre-loaded content if available (from CLI output)
-            const initialContent = window.ALPS_INITIAL_CONTENT || defaultXml;
+            // Use shared URL content first, then pre-loaded content if available (from CLI output)
+            const sharedProfile = await this.loadProfileFromFragment();
+            const initialContent = sharedProfile !== null ? sharedProfile : window.ALPS_INITIAL_CONTENT || defaultXml;
             this.editor.setValue(initialContent);
             // Auto-detect mode
             const trimmed = initialContent.trim();
@@ -483,13 +485,14 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         const params = new URLSearchParams(window.location.search);
         const rawView = params.get('view');
         const rawLabel = params.get('label');
+        const rawHash = this.getProfileFragment() ? '' : window.location.hash;
         return {
             view: ['document', 'diagram', 'preview'].includes(rawView) ? rawView : this.getDefaultViewMode(),
             tag: this.getTagsFromValues(params.getAll('tag')),
             tagOnly: params.get('tagOnly') === '1',
             label: rawLabel === 'title' ? 'title' : 'id',
             size: this.normalizeSizeMode(params.get('size')),
-            hash: window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : ''
+            hash: rawHash ? decodeURIComponent(rawHash.substring(1)) : ''
         };
     }
 
@@ -790,6 +793,96 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             this.downloadFile(content, filename, mimeType);
             this.closeDownloadMenu();
         });
+    }
+
+    setupShareUrlButton() {
+        const button = document.getElementById('shareUrlButton');
+        if (!button) return;
+
+        button.addEventListener('click', async () => {
+            const originalText = button.textContent;
+            button.disabled = true;
+            try {
+                const shareUrl = await this.createProfileShareUrl();
+                if (!navigator.clipboard?.writeText) {
+                    throw new Error('Clipboard API is not available');
+                }
+                await navigator.clipboard.writeText(shareUrl);
+                button.textContent = 'Copied!';
+                setTimeout(() => {
+                    button.textContent = originalText;
+                }, 1500);
+            } catch (error) {
+                this.handleError(error, 'Failed to create Share URL');
+                alert('Failed to copy Share URL');
+            } finally {
+                button.disabled = false;
+            }
+        });
+    }
+
+    async createProfileShareUrl() {
+        if (typeof CompressionStream !== 'function') {
+            throw new Error('CompressionStream is not supported');
+        }
+
+        const compressed = await new Response(
+            new Blob([this.editor.getValue()]).stream().pipeThrough(new CompressionStream('deflate-raw'))
+        ).arrayBuffer();
+        const url = new URL(window.location.href);
+        url.hash = `profile=${this.uint8ArrayToBase64Url(new Uint8Array(compressed))}`;
+        return url.toString();
+    }
+
+    async loadProfileFromFragment() {
+        const encoded = this.getProfileFragment();
+        if (!encoded || typeof DecompressionStream !== 'function') {
+            return null;
+        }
+
+        try {
+            const compressed = this.base64UrlToUint8Array(encoded);
+            return await new Response(
+                new Blob([compressed]).stream().pipeThrough(new DecompressionStream('deflate-raw'))
+            ).text();
+        } catch {
+            return null;
+        }
+    }
+
+    getProfileFragment() {
+        if (!window.location.hash) return '';
+        const params = new URLSearchParams(window.location.hash.substring(1));
+        return params.get('profile') || '';
+    }
+
+    base64UrlToUint8Array(value) {
+        const remainder = value.length % 4;
+        if (remainder === 1) {
+            throw new Error('Invalid base64url');
+        }
+        const padded = value.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - remainder) % 4);
+        const binary = atob(padded);
+        const bytes = new Uint8Array(binary.length);
+
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+
+        return bytes;
+    }
+
+    uint8ArrayToBase64Url(bytes) {
+        let binary = '';
+        const chunkSize = 0x8000;
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+            binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+        }
+
+        return btoa(binary)
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/g, '');
     }
 
     generateMermaid(content) {

--- a/docs/js/styles.css
+++ b/docs/js/styles.css
@@ -39,6 +39,21 @@ body, html {
     cursor: pointer;
 }
 
+#shareUrlButton {
+    margin-right: 5px;
+    padding: 5px 10px;
+    border: none;
+    border-radius: 3px;
+    background-color: #1a73e8;
+    color: white;
+    cursor: pointer;
+}
+
+#shareUrlButton:disabled {
+    background-color: #999;
+    cursor: wait;
+}
+
 #validationMark {
     margin-right: 10px;
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -91,6 +91,18 @@ Get ALPS best practices and reference guide.
 **Example prompt:**
 > "Show me ALPS best practices for naming transitions"
 
+### alps_editor_url
+
+Create a shareable ALPS Editor URL from a local profile file.
+
+**Parameters:**
+- `file` (required): Path to ALPS profile file (XML or JSON format)
+
+**Example prompt:**
+> "Create an ALPS Editor URL for ./api-profile.xml"
+
+URLs longer than 32,000 characters include a note that browsers can open them, but Slack and similar tools may break them.
+
 ## Example Workflow
 
 1. Ask the AI to validate your ALPS profile:
@@ -101,7 +113,10 @@ Get ALPS best practices and reference guide.
 3. Generate a diagram:
    > "Create an SVG diagram from ./my-api.json"
 
-4. Get guidance on improvements:
+4. Share the profile in the online editor:
+   > "Create an ALPS Editor URL for ./my-api.json"
+
+5. Get guidance on improvements:
    > "How should I name my transitions in ALPS?"
 
 ## Validation Codes

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -9,11 +9,15 @@ const {
   handleAlps2Svg,
   handleAlps2Mermaid,
   handleAlpsGuide,
+  handleAlpsEditorUrl,
+  createAlpsEditorUrl,
   handleCrawlAndExtract,
   handleValidateOpenapi,
   getEmbeddedGuide,
 } = require('./index');
 const fs = require('fs');
+const zlib = require('zlib');
+const nodeCrypto = require('crypto');
 const childProcess = require('child_process');
 const util = require('util');
 
@@ -24,6 +28,44 @@ const mockFs = fs as jest.Mocked<typeof fs>;
 // Mock child_process.exec for Spectral tests
 jest.mock('child_process');
 const mockChildProcess = childProcess as jest.Mocked<typeof childProcess>;
+const EDITOR_URL_PREFIX = 'https://editor.app-state-diagram.com/#profile=';
+
+function decodeEditorUrl(url: string): string {
+  expect(url.startsWith(EDITOR_URL_PREFIX)).toBe(true);
+  return zlib.inflateRawSync(Buffer.from(url.slice(EDITOR_URL_PREFIX.length), 'base64url')).toString('utf-8');
+}
+
+function deterministicText(length: number, seed: string): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-';
+  let text = '';
+  let counter = 0;
+
+  while (text.length < length) {
+    const hash = nodeCrypto.createHash('sha256').update(`${seed}:${counter}`).digest();
+    counter++;
+    for (const byte of hash) {
+      text += alphabet[byte % alphabet.length];
+      if (text.length >= length) break;
+    }
+  }
+
+  return text;
+}
+
+function makeLargeAlpsProfile(): string {
+  const descriptor = Array.from({ length: 1030 }, (_, i) => {
+    const hex = ((i * 2654435761) >>> 0).toString(16).padStart(8, '0');
+    return {
+      id: `field${i}_${hex}`,
+      title: `Field ${i} ${hex}`,
+      doc: { value: deterministicText(20, `profile-share-url-${i}`) },
+      type: i % 7 === 0 ? 'safe' : i % 11 === 0 ? 'unsafe' : 'semantic',
+      rt: i % 7 === 0 ? `#State${i % 50}` : undefined,
+    };
+  });
+
+  return JSON.stringify({ alps: { version: '1.0', title: 'Perf Fixture', descriptor } }, null, 2);
+}
 
 describe('MCP Handler Functions', () => {
   beforeEach(() => {
@@ -104,6 +146,84 @@ describe('MCP Handler Functions', () => {
       const result = await handleValidateAlps({ alps_content: alpsContent });
 
       expect(result.content[0].text).toContain('Warnings:');
+    });
+  });
+
+  describe('handleAlpsEditorUrl', () => {
+    it('should generate a base64url raw-deflate editor URL from a file', async () => {
+      const alpsContent = `<?xml version="1.0"?>
+<alps>
+  <descriptor id="Home"/>
+</alps>`;
+
+      mockFs.readFileSync.mockReturnValue(alpsContent);
+
+      const result = await handleAlpsEditorUrl({ file: '/path/to/alps.xml' });
+      const url = result.content[0].text.split('\n').find((line: string) => line.startsWith(EDITOR_URL_PREFIX));
+      const editorUrl = url as string;
+
+      expect(result.isError).toBe(false);
+      expect(mockFs.readFileSync).toHaveBeenCalledWith('/path/to/alps.xml', 'utf-8');
+      expect(url).toBeTruthy();
+      expect(decodeEditorUrl(editorUrl)).toBe(alpsContent);
+      expect(result.content[0].text).not.toContain('Slack');
+    });
+
+    it('should expose the same URL codec through createAlpsEditorUrl', () => {
+      const alpsContent = JSON.stringify({
+        alps: {
+          descriptor: [{ id: 'Home', title: 'Home' }],
+        },
+      });
+
+      const url = createAlpsEditorUrl(alpsContent);
+      const encoded = url.slice(EDITOR_URL_PREFIX.length);
+
+      expect(decodeEditorUrl(url)).toBe(alpsContent);
+      expect(encoded).not.toContain('+');
+      expect(encoded).not.toContain('/');
+      expect(encoded).not.toContain('=');
+    });
+
+    it('should return error when file is missing', async () => {
+      const result = await handleAlpsEditorUrl({});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error: file is required');
+    });
+
+    it('should return error when args is undefined', async () => {
+      const result = await handleAlpsEditorUrl(undefined);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error: file is required');
+    });
+
+    it('should return error when file cannot be read', async () => {
+      mockFs.readFileSync.mockImplementation(() => {
+        throw new Error('File not found');
+      });
+
+      const result = await handleAlpsEditorUrl({ file: '/invalid/alps.json' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error: Cannot read file: /invalid/alps.json');
+    });
+
+    it('should warn when a 196KB profile produces an approximately 47K-character URL', async () => {
+      const alpsContent = makeLargeAlpsProfile();
+      mockFs.readFileSync.mockReturnValue(alpsContent);
+
+      const result = await handleAlpsEditorUrl({ file: '/path/to/large-alps.json' });
+      const url = result.content[0].text.split('\n').find((line: string) => line.startsWith(EDITOR_URL_PREFIX));
+      const editorUrl = url as string;
+
+      expect(Buffer.byteLength(alpsContent, 'utf-8')).toBeGreaterThanOrEqual(196000);
+      expect(url).toBeTruthy();
+      expect(editorUrl.length).toBeGreaterThanOrEqual(46000);
+      expect(editorUrl.length).toBeLessThanOrEqual(49000);
+      expect(decodeEditorUrl(editorUrl)).toBe(alpsContent);
+      expect(result.content[0].text).toContain('ブラウザでは開けるがSlack等では崩れる');
     });
   });
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -13,11 +13,14 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import * as fs from "fs";
 import * as path from "path";
+import * as zlib from "zlib";
 import { fileURLToPath } from "url";
 import { exec } from "child_process";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
+const ALPS_EDITOR_URL_PREFIX = "https://editor.app-state-diagram.com/#profile=";
+const URL_LENGTH_WARNING_THRESHOLD = 32000;
 
 // Import from CLI package
 import { parseAlpsAuto } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
@@ -116,6 +119,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "alps_editor_url",
+        description: "Create a shareable ALPS Editor URL from an ALPS profile file",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            file: {
+              type: "string",
+              description: "Path to ALPS profile file (XML or JSON)",
+            },
+          },
+          required: ["file"],
+        },
+      },
+      {
         name: "crawl_and_extract_alps",
         description: "Crawl website and extract ALPS profile using efficient pattern-based analysis",
         inputSchema: {
@@ -175,6 +192,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return handleAlps2Mermaid(args);
     case "alps_guide":
       return handleAlpsGuide();
+    case "alps_editor_url":
+      return handleAlpsEditorUrl(args);
     case "crawl_and_extract_alps":
       return handleCrawlAndExtract(args);
     case "validate_openapi":
@@ -242,6 +261,51 @@ export async function handleValidateAlps(args: Record<string, unknown> | undefin
       isError: true,
     };
   }
+}
+
+export function createAlpsEditorUrl(alpsContent: string): string {
+  const encoded = zlib.deflateRawSync(Buffer.from(alpsContent, "utf-8")).toString("base64url");
+  return `${ALPS_EDITOR_URL_PREFIX}${encoded}`;
+}
+
+export async function handleAlpsEditorUrl(args: Record<string, unknown> | undefined) {
+  const file = args?.file as string | undefined;
+
+  if (!file) {
+    return {
+      content: [{ type: "text", text: "Error: file is required" }],
+      isError: true,
+    };
+  }
+
+  let alpsContent: string;
+  try {
+    alpsContent = fs.readFileSync(file, "utf-8");
+  } catch {
+    return {
+      content: [{ type: "text", text: `Error: Cannot read file: ${file}` }],
+      isError: true,
+    };
+  }
+
+  const url = createAlpsEditorUrl(alpsContent);
+  const lines = [
+    "✅ ALPS Editor URL generated",
+    "",
+    url,
+  ];
+
+  if (url.length > URL_LENGTH_WARNING_THRESHOLD) {
+    lines.push(
+      "",
+      `注記: ブラウザでは開けるがSlack等では崩れる可能性があります（URL長: ${url.length}文字）。`
+    );
+  }
+
+  return {
+    content: [{ type: "text", text: lines.join("\n") }],
+    isError: false,
+  };
 }
 
 export async function handleAlps2Svg(args: Record<string, unknown> | undefined) {


### PR DESCRIPTION
## Summary
- Load `#profile=<base64url>` editor fragments via native `DecompressionStream('deflate-raw')` and ignore decode failures silently.
- Add a `Share URL` editor action using native `CompressionStream('deflate-raw')`, base64url encoding, and clipboard copy.
- Add the MCP `alps_editor_url` tool with `zlib.deflateRawSync`, base64url output, long-URL warning, and tests for the ~196KB → ~47K URL case.

## Tests
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- Node interop check for `CompressionStream`/`DecompressionStream` with raw deflate
