### PR TITLE
Add XML write support for MCP write tools

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -183,10 +183,10 @@ Enumerate transition paths from one application state to another.
 
 ### alps_set_doc
 
-Set or update the documentation of a descriptor in a JSON ALPS profile. Short single-line docs are stored inline; longer or multi-line docs (Markdown welcome) are automatically written to an external file and linked via `doc.href`.
+Set or update the documentation of a descriptor in a JSON or XML ALPS profile. Short single-line docs are stored inline; longer or multi-line docs (Markdown welcome) are automatically written to an external file and linked via `doc.href`.
 
 **Parameters:**
-- `file` (required): Path to the ALPS profile file (JSON only for writes)
+- `file` (required): Path to the ALPS profile file (JSON or XML)
 - `id` (required): Descriptor id
 - `doc` (required): Documentation text
 - `placement` (optional): `auto` (default) | `inline` | `external`
@@ -196,7 +196,7 @@ Set or update the documentation of a descriptor in a JSON ALPS profile. Short si
 
 ### alps_add_descriptor
 
-Add a new descriptor to a JSON ALPS profile. Containers reference children via `href` fragments (ALPS best practice); missing children are created as top-level semantic descriptors.
+Add a new descriptor to a JSON or XML ALPS profile. Containers reference children via `href` fragments (ALPS best practice); missing children are created as top-level semantic descriptors.
 
 **Parameters:**
 - `file` (required), `id` (required)
@@ -214,7 +214,7 @@ Add a new descriptor to a JSON ALPS profile. Containers reference children via `
 Add and/or remove tags in a descriptor's space-separated `tag` attribute. Kept tags preserve their order, new tags are appended, and the `tag` property is removed when it becomes empty.
 
 **Parameters:**
-- `file` (required): Path to the ALPS profile file (JSON only for writes)
+- `file` (required): Path to the ALPS profile file (JSON or XML)
 - `id` (required): Descriptor id
 - `add` (optional): Tags to add (ones already present are ignored)
 - `remove` (optional): Tags to remove (at least one of `add`/`remove` is required)
@@ -227,12 +227,18 @@ Add and/or remove tags in a descriptor's space-separated `tag` attribute. Kept t
 Rename a descriptor and update all local references across the profile: `href` and `rt` `#fragments` at any nesting depth. Only exact-id matches are rewritten; external references (`file.json#id`) are left untouched. An external doc file (`doc.href`) keeps its old file name — the result reports it as `docFile`; it stays linked and keeps working since the href still points at it.
 
 **Parameters:**
-- `file` (required): Path to the ALPS profile file (JSON only for writes)
+- `file` (required): Path to the ALPS profile file (JSON or XML)
 - `id` (required): Current descriptor id
 - `newId` (required): New descriptor id
 
 **Example prompt:**
 > "Rename Cart to ShoppingCart everywhere"
+
+### XML write behavior and limits
+
+XML write tools load profiles with `fast-xml-parser` in preserve-order mode and write them back with formatted `XMLBuilder` output. Existing element order, existing attribute order, comments, and CDATA nodes are preserved, but XML formatting is normalized (for example, indentation and empty-element spelling may change).
+
+Unsupported XML structures are rejected instead of guessed. In particular, descriptor mixed text content and `doc` elements containing nested markup are not rewritten; convert those profiles to a simpler ALPS XML shape or edit them manually.
 
 ## Auxiliary Design Information (alps/)
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@alps-asd/app-state-diagram": "workspace:*"
+    "@alps-asd/app-state-diagram": "workspace:*",
+    "fast-xml-parser": "^4.5.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/packages/mcp/src/descriptor-store.test.ts
+++ b/packages/mcp/src/descriptor-store.test.ts
@@ -69,11 +69,8 @@ describe("addDescriptor", () => {
     expect(() => addDescriptor(profilePath, { id: "Home" })).toThrow("already exists");
   });
 
-  it("rejects unknown parents and XML profiles", () => {
+  it("rejects unknown parents", () => {
     expect(() => addDescriptor(profilePath, { id: "x", parent: "nope" })).toThrow("Parent descriptor not found");
-    const xml = path.join(dir, "p.xml");
-    fs.writeFileSync(xml, "<alps/>");
-    expect(() => addDescriptor(xml, { id: "x" })).toThrow("JSON profiles only");
   });
 
   it("preserves indentation", () => {
@@ -163,13 +160,10 @@ describe("setDescriptorTags", () => {
     );
   });
 
-  it("rejects unknown ids and XML profiles", () => {
+  it("rejects unknown ids", () => {
     expect(() => setDescriptorTags(profilePath, { id: "nope", add: ["x"] })).toThrow(
       "Descriptor not found"
     );
-    const xml = path.join(dir, "p.xml");
-    fs.writeFileSync(xml, "<alps/>");
-    expect(() => setDescriptorTags(xml, { id: "Home", add: ["x"] })).toThrow("JSON profiles only");
   });
 
   it("preserves indentation", () => {
@@ -248,12 +242,6 @@ describe("renameDescriptor", () => {
     expect(() => renameDescriptor(profilePath, "Nope", "Whatever")).toThrow(
       "Descriptor not found: Nope"
     );
-  });
-
-  it("rejects XML profiles", () => {
-    const xml = path.join(dir, "p.xml");
-    fs.writeFileSync(xml, "<alps/>");
-    expect(() => renameDescriptor(xml, "Cart", "Basket")).toThrow("JSON profiles only");
   });
 
   it("preserves indentation", () => {

--- a/packages/mcp/src/descriptor-store.ts
+++ b/packages/mcp/src/descriptor-store.ts
@@ -1,5 +1,5 @@
 /**
- * Descriptor store - create descriptors in a JSON ALPS profile
+ * Descriptor store - create descriptors in a JSON or XML ALPS profile
  *
  * Like doc-store, edits the raw JSON surgically (preserving indentation
  * and everything else in the profile) rather than re-serializing a
@@ -13,6 +13,7 @@ import * as path from "path";
 import { findDescriptorById, walkDescriptors } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
 import type { AlpsDescriptor } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
 import { serializeLike } from "./doc-store.js";
+import { addXmlDescriptor, renameXmlDescriptor, setXmlDescriptorTags } from "./xml-store.js";
 
 export interface AddDescriptorInput {
   id: string;
@@ -72,7 +73,7 @@ function assertValidId(id: string, label: string): void {
 }
 
 /**
- * Add a new descriptor to a JSON ALPS profile file
+ * Add a new descriptor to a JSON or XML ALPS profile file
  */
 export function addDescriptor(profilePath: string, input: AddDescriptorInput): AddDescriptorResult {
   assertValidId(input.id, "Descriptor id");
@@ -85,10 +86,7 @@ export function addDescriptor(profilePath: string, input: AddDescriptorInput): A
   }
   const content = fs.readFileSync(absPath, "utf-8");
   if (!content.trim().startsWith("{")) {
-    throw new Error(
-      "Writing descriptors is currently supported for JSON profiles only. " +
-        "Convert the XML profile to JSON, or edit the XML directly."
-    );
+    return addXmlDescriptor(absPath, input);
   }
 
   let root: { alps?: { descriptor?: unknown } };
@@ -175,10 +173,7 @@ export function setDescriptorTags(profilePath: string, input: SetTagsInput): Set
   }
   const content = fs.readFileSync(absPath, "utf-8");
   if (!content.trim().startsWith("{")) {
-    throw new Error(
-      "Writing tags is currently supported for JSON profiles only. " +
-        "Convert the XML profile to JSON, or edit the XML directly."
-    );
+    return setXmlDescriptorTags(absPath, input);
   }
 
   let root: { alps?: { descriptor?: unknown } };
@@ -229,10 +224,7 @@ export function renameDescriptor(profilePath: string, oldId: string, newId: stri
   }
   const content = fs.readFileSync(absPath, "utf-8");
   if (!content.trim().startsWith("{")) {
-    throw new Error(
-      "Renaming descriptors is currently supported for JSON profiles only. " +
-        "Convert the XML profile to JSON, or edit the XML directly."
-    );
+    return renameXmlDescriptor(absPath, oldId, newId);
   }
 
   let root: { alps?: { descriptor?: unknown } };

--- a/packages/mcp/src/doc-store.test.ts
+++ b/packages/mcp/src/doc-store.test.ts
@@ -195,10 +195,11 @@ describe('setDescriptorDoc', () => {
     expect(() => setDescriptorDoc(profilePath, 'Nope', 'doc')).toThrow('Descriptor not found');
   });
 
-  it('rejects XML profiles', () => {
+  it('writes XML profiles', () => {
     const xmlPath = path.join(dir, 'profile.xml');
     fs.writeFileSync(xmlPath, '<alps><descriptor id="Home"/></alps>');
-    expect(() => setDescriptorDoc(xmlPath, 'Home', 'doc')).toThrow('JSON profiles only');
+    expect(setDescriptorDoc(xmlPath, 'Home', 'doc')).toEqual({ id: 'Home', placement: 'inline' });
+    expect(fs.readFileSync(xmlPath, 'utf-8')).toContain('<doc>doc</doc>');
   });
 
   it('rejects missing files', () => {

--- a/packages/mcp/src/doc-store.ts
+++ b/packages/mcp/src/doc-store.ts
@@ -16,11 +16,16 @@ import * as fs from "fs";
 import * as path from "path";
 import { findDescriptorById } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
 import type { AlpsDoc } from "@alps-asd/app-state-diagram/parser/alps-parser.js";
+import {
+  DOC_DIR,
+  INLINE_DOC_MAX_LENGTH,
+  resolveSafeLocalPath,
+  safeFileName,
+  shouldExternalize,
+} from "./doc-utils.js";
+import { setXmlDescriptorDoc } from "./xml-store.js";
 
-export const DOC_DIR = "alps/docs";
-
-/** Docs longer than this (or multi-line) are stored in an external file */
-export const INLINE_DOC_MAX_LENGTH = 200;
+export { DOC_DIR, INLINE_DOC_MAX_LENGTH, resolveSafeLocalPath, shouldExternalize };
 
 export type DocPlacement = "auto" | "inline" | "external";
 
@@ -34,14 +39,7 @@ export interface SetDocResult {
 }
 
 /**
- * Decide whether a doc should be stored in an external file
- */
-export function shouldExternalize(doc: string): boolean {
-  return doc.length > INLINE_DOC_MAX_LENGTH || doc.includes("\n");
-}
-
-/**
- * Set or update the doc of a descriptor in a JSON ALPS profile file.
+ * Set or update the doc of a descriptor in a JSON or XML ALPS profile file.
  *
  * With placement 'auto', the doc is stored externally when it is large
  * (see shouldExternalize) or when the descriptor already links a local
@@ -60,10 +58,7 @@ export function setDescriptorDoc(
 
   const content = fs.readFileSync(absPath, "utf-8");
   if (!content.trim().startsWith("{")) {
-    throw new Error(
-      "Writing docs is currently supported for JSON profiles only. " +
-        "Convert the XML profile to JSON, or edit the XML directly."
-    );
+    return setXmlDescriptorDoc(absPath, id, doc, placement);
   }
 
   let root: any;
@@ -150,53 +145,6 @@ export function resolveDoc(
     }
   }
   return { text: doc.value || "", href: doc.href, format: doc.format };
-}
-
-/**
- * Resolve a local href (doc.href, describedby link) against the profile
- * directory, rejecting anything that escapes it: URL schemes ("http:",
- * "file:", Windows drives), protocol-relative or absolute paths,
- * backslashes, and ../ traversal. Symlinks inside the profile directory
- * are legitimate (e.g. compat links keeping old layouts working), but
- * their real targets must stay inside it. Returns the absolute path, or
- * undefined when unsafe.
- */
-export function resolveSafeLocalPath(baseDir: string, href: string): string | undefined {
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
-    return undefined;
-  }
-  if (href.startsWith("//") || href.includes("\\") || path.isAbsolute(href)) {
-    return undefined;
-  }
-  const abs = path.resolve(baseDir, href);
-  const rel = path.relative(baseDir, abs);
-  if (rel.startsWith("..") || path.isAbsolute(rel)) {
-    return undefined;
-  }
-  // Compare real paths so a symlinked component cannot escape baseDir.
-  // The target file may not exist yet (first write), so check the
-  // deepest existing ancestor instead.
-  try {
-    const baseReal = fs.realpathSync(baseDir);
-    let existing = abs;
-    while (!fs.existsSync(existing)) {
-      existing = path.dirname(existing);
-    }
-    const existingReal = fs.realpathSync(existing);
-    if (existingReal !== baseReal && !existingReal.startsWith(baseReal + path.sep)) {
-      return undefined;
-    }
-  } catch {
-    return undefined;
-  }
-  return abs;
-}
-
-/**
- * Turn a descriptor id into a safe file name for alps/docs/
- */
-function safeFileName(id: string): string {
-  return id.replace(/[^A-Za-z0-9._-]/g, "-");
 }
 
 /**

--- a/packages/mcp/src/doc-utils.ts
+++ b/packages/mcp/src/doc-utils.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export const DOC_DIR = "alps/docs";
+export const INLINE_DOC_MAX_LENGTH = 200;
+
+export function shouldExternalize(doc: string): boolean {
+  return doc.length > INLINE_DOC_MAX_LENGTH || doc.includes("\n");
+}
+
+export function resolveSafeLocalPath(baseDir: string, href: string): string | undefined {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
+    return undefined;
+  }
+  if (href.startsWith("//") || href.includes("\\") || path.isAbsolute(href)) {
+    return undefined;
+  }
+  const abs = path.resolve(baseDir, href);
+  const rel = path.relative(baseDir, abs);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    return undefined;
+  }
+  try {
+    const baseReal = fs.realpathSync(baseDir);
+    let existing = abs;
+    while (!fs.existsSync(existing)) {
+      existing = path.dirname(existing);
+    }
+    const existingReal = fs.realpathSync(existing);
+    if (existingReal !== baseReal && !existingReal.startsWith(baseReal + path.sep)) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return abs;
+}
+
+export function safeFileName(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, "-");
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -320,7 +320,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "alps_set_doc",
         description:
-          "Set or update the documentation of a descriptor in a JSON ALPS profile. " +
+          "Set or update the documentation of a descriptor in a JSON or XML ALPS profile. " +
           `Short single-line docs (<= ${INLINE_DOC_MAX_LENGTH} chars) are stored inline; ` +
           "longer or multi-line docs are automatically written to an external Markdown " +
           "file (alps/docs/<id>.md) and linked from the profile via doc.href. This keeps " +
@@ -352,13 +352,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "alps_add_descriptor",
-        description: "Add a new descriptor to a JSON ALPS profile. Containers reference children via href fragments; missing children are created as top-level semantic descriptors. Example: register name and age as person -> id: person, children: [name, age].",
+        description: "Add a new descriptor to a JSON or XML ALPS profile. Containers reference children via href fragments; missing children are created as top-level semantic descriptors. Example: register name and age as person -> id: person, children: [name, age].",
         inputSchema: {
           type: "object" as const,
           properties: {
             file: {
               type: "string",
-              description: "Path to the ALPS profile file (JSON only for writes)",
+              description: "Path to the ALPS profile file (JSON or XML)",
             },
             id: {
               type: "string",
@@ -401,13 +401,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "alps_set_tags",
         description:
-          "Add and/or remove tags in a descriptor's space-separated tag attribute in a JSON ALPS profile. Kept tags preserve their order, new tags are appended, and the tag property is removed when it becomes empty.",
+          "Add and/or remove tags in a descriptor's space-separated tag attribute in a JSON or XML ALPS profile. Kept tags preserve their order, new tags are appended, and the tag property is removed when it becomes empty.",
         inputSchema: {
           type: "object" as const,
           properties: {
             file: {
               type: "string",
-              description: "Path to the ALPS profile file (JSON only for writes)",
+              description: "Path to the ALPS profile file (JSON or XML)",
             },
             id: {
               type: "string",
@@ -430,13 +430,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "alps_rename",
         description:
-          "Rename a descriptor in a JSON ALPS profile and update all local references: href and rt #fragments at any nesting depth. External references (file.json#id) are left untouched. An external doc file (doc.href) keeps its old file name but stays linked.",
+          "Rename a descriptor in a JSON or XML ALPS profile and update all local references: href and rt #fragments at any nesting depth. External references (file.json#id) are left untouched. An external doc file (doc.href) keeps its old file name but stays linked.",
         inputSchema: {
           type: "object" as const,
           properties: {
             file: {
               type: "string",
-              description: "Path to the ALPS profile file (JSON only for writes)",
+              description: "Path to the ALPS profile file (JSON or XML)",
             },
             id: {
               type: "string",
@@ -629,7 +629,7 @@ export async function handleAlpsEditorUrl(args: Record<string, unknown> | undefi
 }
 
 /**
- * Add a new descriptor (optionally nested or with href children) to a JSON profile
+ * Add a new descriptor (optionally nested or with href children) to a JSON or XML profile
  */
 export async function handleAlpsAddDescriptor(args: Record<string, unknown> | undefined) {
   const file = args?.file as string | undefined;
@@ -676,7 +676,7 @@ export async function handleAlpsAddDescriptor(args: Record<string, unknown> | un
 }
 
 /**
- * Add and/or remove tags on a descriptor in a JSON profile
+ * Add and/or remove tags on a descriptor in a JSON or XML profile
  */
 export async function handleAlpsSetTags(args: Record<string, unknown> | undefined) {
   const file = args?.file as string | undefined;
@@ -704,7 +704,7 @@ export async function handleAlpsSetTags(args: Record<string, unknown> | undefine
 }
 
 /**
- * Rename a descriptor and update local #fragment references across a JSON profile
+ * Rename a descriptor and update local #fragment references across a JSON or XML profile
  */
 export async function handleAlpsRename(args: Record<string, unknown> | undefined) {
   const file = args?.file as string | undefined;

--- a/packages/mcp/src/xml-store.test.ts
+++ b/packages/mcp/src/xml-store.test.ts
@@ -1,0 +1,114 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { addDescriptor, renameDescriptor, setDescriptorTags } from "./descriptor-store.js";
+import { DOC_DIR, setDescriptorDoc } from "./doc-store.js";
+import { parseXmlPreserveOrder, serializeXml } from "./xml-store.js";
+
+const XML_FIXTURE = `<?xml version="1.0"?>
+<alps version="1.0">
+  <!-- profile comment -->
+  <descriptor id="Home" type="semantic" title="Homepage" tag="nav old">
+    <doc><![CDATA[Keep <xml> docs]]></doc>
+    <descriptor href="#goCart"/>
+    <descriptor id="section">
+      <descriptor href="#Cart"/>
+    </descriptor>
+  </descriptor>
+  <descriptor id="Cart">
+    <doc href="alps/docs/Cart.md" format="markdown"/>
+  </descriptor>
+  <descriptor id="goCart" type="safe" rt="#Cart"/>
+  <descriptor id="shared" href="shared.xml#Cart"/>
+</alps>
+`;
+let dir: string;
+let profilePath: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "xml-store-"));
+  profilePath = path.join(dir, "profile.xml");
+  fs.writeFileSync(profilePath, XML_FIXTURE);
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+const readXml = () => fs.readFileSync(profilePath, "utf-8");
+function expectXmlEquivalentTo(expected: string): void {
+  const actual = readXml();
+  expect(parseXmlPreserveOrder(actual)).toEqual(parseXmlPreserveOrder(expected));
+  expect(actual).toContain("<!-- profile comment -->");
+  expect(actual).toContain("<![CDATA[Keep <xml> docs]]>");
+  expect(serializeXml(parseXmlPreserveOrder(actual))).toBe(actual);
+}
+
+describe("XML write support", () => {
+  it("sets descriptor docs in XML and externalizes long docs", () => {
+    const doc = "# Shared\n\nDetailed documentation.";
+    expect(setDescriptorDoc(profilePath, "shared", doc)).toEqual({ id: "shared", placement: "external", docFile: `${DOC_DIR}/shared.md` });
+    expect(fs.readFileSync(path.join(dir, DOC_DIR, "shared.md"), "utf-8")).toBe(`${doc}\n`);
+    expectXmlEquivalentTo(`<?xml version="1.0"?>
+<alps version="1.0">
+  <!-- profile comment -->
+  <descriptor id="Home" type="semantic" title="Homepage" tag="nav old">
+    <doc><![CDATA[Keep <xml> docs]]></doc>
+    <descriptor href="#goCart"/>
+    <descriptor id="section"><descriptor href="#Cart"/></descriptor>
+  </descriptor>
+  <descriptor id="Cart"><doc href="alps/docs/Cart.md" format="markdown"/></descriptor>
+  <descriptor id="goCart" type="safe" rt="#Cart"/>
+  <descriptor id="shared" href="shared.xml#Cart"><doc href="alps/docs/shared.md" format="markdown"/></descriptor>
+</alps>
+`);
+  });
+
+  it("adds descriptors in XML, preserving existing comments and CDATA", () => {
+    expect(addDescriptor(profilePath, { id: "person", title: "Person", children: ["name", "age"] })).toEqual({ id: "person", createdChildren: ["name", "age"], warnings: [] });
+    expectXmlEquivalentTo(`<?xml version="1.0"?>
+<alps version="1.0">
+  <!-- profile comment -->
+  <descriptor id="Home" type="semantic" title="Homepage" tag="nav old">
+    <doc><![CDATA[Keep <xml> docs]]></doc>
+    <descriptor href="#goCart"/>
+    <descriptor id="section"><descriptor href="#Cart"/></descriptor>
+  </descriptor>
+  <descriptor id="Cart"><doc href="alps/docs/Cart.md" format="markdown"/></descriptor>
+  <descriptor id="goCart" type="safe" rt="#Cart"/>
+  <descriptor id="shared" href="shared.xml#Cart"/>
+  <descriptor id="name"/>
+  <descriptor id="age"/>
+  <descriptor id="person" title="Person"><descriptor href="#name"/><descriptor href="#age"/></descriptor>
+</alps>
+`);
+  });
+
+  it("sets XML descriptor tags without moving existing attributes", () => {
+    expect(setDescriptorTags(profilePath, { id: "Home", add: ["core"], remove: ["old"] })).toEqual({ id: "Home", tags: ["nav", "core"], added: ["core"], removed: ["old"] });
+    expect(readXml()).toContain('<descriptor id="Home" type="semantic" title="Homepage" tag="nav core">');
+    expectXmlEquivalentTo(XML_FIXTURE.replace('tag="nav old"', 'tag="nav core"'));
+  });
+
+  it("renames XML descriptors and local references only", () => {
+    expect(renameDescriptor(profilePath, "Cart", "Basket")).toEqual({ id: "Basket", previousId: "Cart", referencesUpdated: 2, docFile: "alps/docs/Cart.md" });
+    expectXmlEquivalentTo(`<?xml version="1.0"?>
+<alps version="1.0">
+  <!-- profile comment -->
+  <descriptor id="Home" type="semantic" title="Homepage" tag="nav old">
+    <doc><![CDATA[Keep <xml> docs]]></doc>
+    <descriptor href="#goCart"/>
+    <descriptor id="section"><descriptor href="#Basket"/></descriptor>
+  </descriptor>
+  <descriptor id="Basket"><doc href="alps/docs/Cart.md" format="markdown"/></descriptor>
+  <descriptor id="goCart" type="safe" rt="#Basket"/>
+  <descriptor id="shared" href="shared.xml#Cart"/>
+</alps>
+`);
+  });
+
+  it("reports malformed XML clearly", () => {
+    fs.writeFileSync(profilePath, '<alps><descriptor id="Home"></alps>');
+    expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["nav"] })).toThrow(/Invalid XML format: Expected closing tag/);
+  });
+
+  it("rejects unsupported mixed-content descriptor structures", () => {
+    fs.writeFileSync(profilePath, '<alps><descriptor id="Home">text<descriptor id="child"/></descriptor></alps>');
+    expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["nav"] })).toThrow('Unsupported XML structure: descriptor "Home" contains mixed text content');
+  });
+});

--- a/packages/mcp/src/xml-store.test.ts
+++ b/packages/mcp/src/xml-store.test.ts
@@ -111,4 +111,62 @@ describe("XML write support", () => {
     fs.writeFileSync(profilePath, '<alps><descriptor id="Home">text<descriptor id="child"/></descriptor></alps>');
     expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["nav"] })).toThrow('Unsupported XML structure: descriptor "Home" contains mixed text content');
   });
+  it("updates an existing inline XML doc in place", () => {
+    expect(setDescriptorDoc(profilePath, "Home", "Plain doc.")).toEqual({ id: "Home", placement: "inline" });
+    const xml = readXml();
+    expect(xml).toContain("<doc>Plain doc.</doc>");
+    expect(xml).not.toContain("Keep <xml> docs");
+  });
+
+  it("forces inline placement on an external XML doc and reports the orphan", () => {
+    expect(setDescriptorDoc(profilePath, "Cart", "Inline now.", "inline")).toEqual({
+      id: "Cart",
+      placement: "inline",
+      orphanedDocFile: "alps/docs/Cart.md",
+    });
+    expectXmlEquivalentTo(XML_FIXTURE.replace(
+      '<doc href="alps/docs/Cart.md" format="markdown"/>',
+      '<doc>Inline now.</doc>'
+    ));
+  });
+
+  it("rejects duplicate descriptor ids in XML", () => {
+    expect(() => addDescriptor(profilePath, { id: "Home" })).toThrow("Descriptor already exists: Home");
+  });
+
+  it("normalizes rt fragments and warns about missing XML targets", () => {
+    expect(addDescriptor(profilePath, { id: "goNowhere", type: "safe", title: "Go", rt: "Nowhere", tag: "nav" })).toEqual({
+      id: "goNowhere",
+      createdChildren: [],
+      warnings: ['rt target "#Nowhere" does not exist yet'],
+    });
+    expect(addDescriptor(profilePath, { id: "goCartAgain", type: "safe", rt: "#Cart" })).toEqual({ id: "goCartAgain", createdChildren: [], warnings: [] });
+    expectXmlEquivalentTo(XML_FIXTURE.replace(
+      '</alps>',
+      '  <descriptor id="goNowhere" type="safe" title="Go" rt="#Nowhere" tag="nav"/>\n  <descriptor id="goCartAgain" type="safe" rt="#Cart"/>\n</alps>'
+    ));
+  });
+
+  it("nests new XML descriptors under a parent", () => {
+    addDescriptor(profilePath, { id: "headline", parent: "section" });
+    expectXmlEquivalentTo(XML_FIXTURE.replace(
+      '<descriptor id="section">\n      <descriptor href="#Cart"/>\n    </descriptor>',
+      '<descriptor id="section"><descriptor href="#Cart"/><descriptor id="headline"/></descriptor>'
+    ));
+    expect(() => addDescriptor(profilePath, { id: "stray", parent: "ghost" })).toThrow("Parent descriptor not found: ghost");
+  });
+
+  it("rejects alps elements with mixed text content", () => {
+    fs.writeFileSync(profilePath, '<alps>stray text<descriptor id="Home"/></alps>');
+    expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["nav"] })).toThrow(
+      "Unsupported XML structure: alps contains mixed text content"
+    );
+  });
+  it("does not reuse unsafe XML doc.href values as write targets", () => {
+    fs.writeFileSync(profilePath, '<alps><descriptor id="Home"><doc href="../escape.md"/></descriptor></alps>');
+    expect(setDescriptorDoc(profilePath, "Home", "Safe doc.")).toEqual({ id: "Home", placement: "inline" });
+    expect(readXml()).toContain("<doc>Safe doc.</doc>");
+    expect(readXml()).not.toContain("escape.md");
+    expect(fs.existsSync(path.join(dir, "..", "escape.md"))).toBe(false);
+  });
 });

--- a/packages/mcp/src/xml-store.test.ts
+++ b/packages/mcp/src/xml-store.test.ts
@@ -3,7 +3,14 @@ import * as os from "os";
 import * as path from "path";
 import { addDescriptor, renameDescriptor, setDescriptorTags } from "./descriptor-store.js";
 import { DOC_DIR, setDescriptorDoc } from "./doc-store.js";
-import { parseXmlPreserveOrder, serializeXml } from "./xml-store.js";
+import {
+  addXmlDescriptor,
+  parseXmlPreserveOrder,
+  renameXmlDescriptor,
+  serializeXml,
+  setXmlDescriptorDoc,
+  setXmlDescriptorTags,
+} from "./xml-store.js";
 
 const XML_FIXTURE = `<?xml version="1.0"?>
 <alps version="1.0">
@@ -59,6 +66,21 @@ describe("XML write support", () => {
 `);
   });
 
+  it("updates existing external XML docs in place preserving format", () => {
+    const docFile = path.join(dir, DOC_DIR, "Cart.md");
+    fs.mkdirSync(path.dirname(docFile), { recursive: true });
+    const doc = "Already newline\n";
+
+    expect(setDescriptorDoc(profilePath, "Cart", doc)).toEqual({
+      id: "Cart",
+      placement: "external",
+      docFile: "alps/docs/Cart.md",
+    });
+
+    expect(fs.readFileSync(docFile, "utf-8")).toBe(doc);
+    expect(readXml()).toContain('<doc href="alps/docs/Cart.md" format="markdown">');
+  });
+
   it("adds descriptors in XML, preserving existing comments and CDATA", () => {
     expect(addDescriptor(profilePath, { id: "person", title: "Person", children: ["name", "age"] })).toEqual({ id: "person", createdChildren: ["name", "age"], warnings: [] });
     expectXmlEquivalentTo(`<?xml version="1.0"?>
@@ -107,9 +129,47 @@ describe("XML write support", () => {
     expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["nav"] })).toThrow(/Invalid XML format: Expected closing tag/);
   });
 
+  it("reports malformed empty XML without a location suffix", () => {
+    expect(() => parseXmlPreserveOrder("")).toThrow("Invalid XML format: Start tag expected.");
+  });
+
+  it("reports missing XML descriptors and missing files", () => {
+    expect(() => setDescriptorDoc(profilePath, "Missing", "doc")).toThrow("Descriptor not found: Missing");
+    expect(() => setXmlDescriptorDoc(path.join(dir, "missing.xml"), "Home", "doc")).toThrow(
+      "Profile file not found"
+    );
+  });
+
+  it("rejects XML doc paths that resolve outside the profile directory", () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "xml-store-outside-"));
+    try {
+      fs.symlinkSync(outside, path.join(dir, "alps"));
+
+      expect(() => setXmlDescriptorDoc(profilePath, "shared", "x\ny", "external")).toThrow(
+        "Unsafe doc path: alps/docs/shared.md"
+      );
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects XML without an alps element", () => {
+    fs.writeFileSync(profilePath, '<profile><descriptor id="Home"/></profile>');
+
+    expect(() => setDescriptorDoc(profilePath, "Home", "doc")).toThrow("No alps element found in XML");
+  });
+
   it("rejects unsupported mixed-content descriptor structures", () => {
     fs.writeFileSync(profilePath, '<alps><descriptor id="Home">text<descriptor id="child"/></descriptor></alps>');
     expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["nav"] })).toThrow('Unsupported XML structure: descriptor "Home" contains mixed text content');
+  });
+
+  it("rejects XML doc elements with nested markup", () => {
+    fs.writeFileSync(profilePath, '<alps><descriptor id="Home"><doc><p>Rich</p></doc></descriptor></alps>');
+
+    expect(() => setDescriptorTags(profilePath, { id: "Home", add: ["nav"] })).toThrow(
+      'Unsupported XML structure: doc for descriptor "Home" contains mixed content'
+    );
   });
   it("updates an existing inline XML doc in place", () => {
     expect(setDescriptorDoc(profilePath, "Home", "Plain doc.")).toEqual({ id: "Home", placement: "inline" });
@@ -134,6 +194,18 @@ describe("XML write support", () => {
     expect(() => addDescriptor(profilePath, { id: "Home" })).toThrow("Descriptor already exists: Home");
   });
 
+  it("does not create duplicate XML children when children already exist or reference self", () => {
+    expect(addDescriptor(profilePath, { id: "person", children: ["Cart", "person"] })).toEqual({
+      id: "person",
+      createdChildren: [],
+      warnings: [],
+    });
+    expectXmlEquivalentTo(XML_FIXTURE.replace(
+      '</alps>',
+      '  <descriptor id="person"><descriptor href="#Cart"/><descriptor href="#person"/></descriptor>\n</alps>'
+    ));
+  });
+
   it("normalizes rt fragments and warns about missing XML targets", () => {
     expect(addDescriptor(profilePath, { id: "goNowhere", type: "safe", title: "Go", rt: "Nowhere", tag: "nav" })).toEqual({
       id: "goNowhere",
@@ -147,6 +219,15 @@ describe("XML write support", () => {
     ));
   });
 
+  it("leaves external XML rt references untouched without warnings", () => {
+    expect(addXmlDescriptor(profilePath, { id: "goExternal", type: "safe", rt: "shared.xml#Cart" })).toEqual({
+      id: "goExternal",
+      createdChildren: [],
+      warnings: [],
+    });
+    expect(readXml()).toContain('<descriptor id="goExternal" type="safe" rt="shared.xml#Cart">');
+  });
+
   it("nests new XML descriptors under a parent", () => {
     addDescriptor(profilePath, { id: "headline", parent: "section" });
     expectXmlEquivalentTo(XML_FIXTURE.replace(
@@ -154,6 +235,56 @@ describe("XML write support", () => {
       '<descriptor id="section"><descriptor href="#Cart"/><descriptor id="headline"/></descriptor>'
     ));
     expect(() => addDescriptor(profilePath, { id: "stray", parent: "ghost" })).toThrow("Parent descriptor not found: ghost");
+  });
+
+  it("inserts XML docs before existing child descriptors", () => {
+    expect(setDescriptorDoc(profilePath, "section", "Section doc.")).toEqual({
+      id: "section",
+      placement: "inline",
+    });
+    expectXmlEquivalentTo(XML_FIXTURE.replace(
+      '<descriptor id="section">\n      <descriptor href="#Cart"/>\n    </descriptor>',
+      '<descriptor id="section"><doc>Section doc.</doc><descriptor href="#Cart"/></descriptor>'
+    ));
+  });
+
+  it("sets, removes, and validates XML descriptor tags", () => {
+    expect(setDescriptorTags(profilePath, { id: "shared", add: ["nav", "nav"] })).toEqual({
+      id: "shared",
+      tags: ["nav"],
+      added: ["nav"],
+      removed: [],
+    });
+    expect(setDescriptorTags(profilePath, { id: "shared", remove: ["nav"] })).toEqual({
+      id: "shared",
+      tags: [],
+      added: [],
+      removed: ["nav"],
+    });
+    expect(readXml()).toContain('<descriptor id="shared" href="shared.xml#Cart">');
+    expect(() => setDescriptorTags(profilePath, { id: "Home" })).toThrow(
+      "At least one of add or remove is required"
+    );
+    expect(() => setXmlDescriptorTags(profilePath, { id: "Home" })).toThrow(
+      "At least one of add or remove is required"
+    );
+    expect(() => setDescriptorTags(profilePath, { id: "Missing", add: ["nav"] })).toThrow(
+      "Descriptor not found: Missing"
+    );
+    fs.writeFileSync(profilePath, "<alps><descriptor/></alps>");
+    expect(() => setXmlDescriptorTags(profilePath, { id: "Missing", add: ["nav"] })).toThrow(
+      "Descriptor not found: Missing"
+    );
+  });
+
+  it("renames XML descriptors without doc files and validates rename errors", () => {
+    expect(renameDescriptor(profilePath, "shared", "sharedNew")).toEqual({
+      id: "sharedNew",
+      previousId: "shared",
+      referencesUpdated: 0,
+    });
+    expect(() => renameXmlDescriptor(profilePath, "Missing", "Other")).toThrow("Descriptor not found: Missing");
+    expect(() => renameXmlDescriptor(profilePath, "Home", "Cart")).toThrow("Descriptor already exists: Cart");
   });
 
   it("rejects alps elements with mixed text content", () => {

--- a/packages/mcp/src/xml-store.ts
+++ b/packages/mcp/src/xml-store.ts
@@ -1,0 +1,250 @@
+import * as fs from "fs";
+import * as path from "path";
+import { XMLBuilder, XMLParser, XMLValidator } from "fast-xml-parser";
+import type { AddDescriptorInput, AddDescriptorResult, RenameResult, SetTagsInput, SetTagsResult } from "./descriptor-store.js";
+import type { DocPlacement, SetDocResult } from "./doc-store.js";
+import { DOC_DIR, resolveSafeLocalPath, safeFileName, shouldExternalize } from "./doc-utils.js";
+
+const ATTRS = ":@";
+const ATTR_PREFIX = "@_";
+const TEXT = "#text";
+const COMMENT = "#comment";
+const CDATA = "#cdata";
+const XML_OPTIONS = {
+  preserveOrder: true,
+  ignoreAttributes: false,
+  commentPropName: COMMENT,
+  cdataPropName: CDATA,
+} as const;
+
+type XmlAttrs = Record<string, string>;
+type XmlNode = Record<string, unknown>;
+interface LoadedXmlProfile { absPath: string; baseDir: string; tree: XmlNode[]; alpsNode: XmlNode }
+
+export function setXmlDescriptorDoc(profilePath: string, id: string, doc: string, placement: DocPlacement = "auto"): SetDocResult {
+  const profile = loadXmlProfile(profilePath);
+  const descriptor = findXmlDescriptorById(profile.alpsNode, id);
+  if (!descriptor) throw new Error(`Descriptor not found: ${id}`);
+
+  const existingDocNode = directChildElement(descriptor, "doc");
+  const existingHref = existingDocNode ? getAttr(existingDocNode, "href") : undefined;
+  const hasExternalDoc = existingHref !== undefined && resolveSafeLocalPath(profile.baseDir, existingHref) !== undefined;
+  const external = placement === "auto" ? hasExternalDoc || shouldExternalize(doc) : placement === "external";
+  const result: SetDocResult = { id, placement: external ? "external" : "inline" };
+  const docNode = existingDocNode ?? insertDocNode(descriptor);
+
+  if (external) {
+    const docFile = hasExternalDoc ? existingHref! : `${DOC_DIR}/${safeFileName(id)}.md`;
+    const docFilePath = resolveSafeLocalPath(profile.baseDir, docFile);
+    if (!docFilePath) throw new Error(`Unsafe doc path: ${docFile}`);
+    fs.mkdirSync(path.dirname(docFilePath), { recursive: true });
+    fs.writeFileSync(docFilePath, doc.endsWith("\n") ? doc : `${doc}\n`, "utf-8");
+    const format = hasExternalDoc && getAttr(docNode, "format") ? getAttr(docNode, "format")! : "markdown";
+    setElementAttrs(docNode, orderedAttrs([["href", docFile], ["format", format]]));
+    setElementChildren(docNode, []);
+    result.docFile = docFile;
+  } else {
+    if (hasExternalDoc) {
+      result.orphanedDocFile = existingHref;
+      setElementAttrs(docNode, {});
+    } else if (existingDocNode) {
+      deleteAttr(docNode, "href");
+    }
+    setElementChildren(docNode, [textNode(doc)]);
+  }
+  writeXmlProfile(profile);
+  return result;
+}
+
+export function addXmlDescriptor(profilePath: string, input: AddDescriptorInput): AddDescriptorResult {
+  const profile = loadXmlProfile(profilePath);
+  if (findXmlDescriptorById(profile.alpsNode, input.id)) {
+    throw new Error(`Descriptor already exists: ${input.id} (use alps_set_doc to update its documentation)`);
+  }
+  const warnings: string[] = [];
+  const attrs: Array<[string, string | undefined]> = [["id", input.id]];
+  if (input.type && input.type !== "semantic") attrs.push(["type", input.type]);
+  if (input.title) attrs.push(["title", input.title]);
+  if (input.rt) {
+    const rt = /^#|:|\//.test(input.rt) || input.rt.includes("#") ? input.rt : `#${input.rt}`;
+    attrs.push(["rt", rt]);
+    const target = rt.startsWith("#") ? rt.substring(1) : null;
+    if (target && !findXmlDescriptorById(profile.alpsNode, target)) warnings.push(`rt target "#${target}" does not exist yet`);
+  }
+  if (input.tag) attrs.push(["tag", input.tag]);
+
+  const descriptor = makeElement("descriptor", [], orderedAttrs(attrs));
+  const createdChildren: string[] = [];
+  if (input.children?.length) {
+    setElementChildren(descriptor, input.children.map((childId) => makeElement("descriptor", [], orderedAttrs([["href", `#${childId}`]]))));
+    for (const childId of input.children) {
+      if (!findXmlDescriptorById(profile.alpsNode, childId) && childId !== input.id) {
+        alpsChildren(profile.alpsNode).push(makeElement("descriptor", [], orderedAttrs([["id", childId]])));
+        createdChildren.push(childId);
+      }
+    }
+  }
+
+  if (input.parent) {
+    const parent = findXmlDescriptorById(profile.alpsNode, input.parent);
+    if (!parent) throw new Error(`Parent descriptor not found: ${input.parent}`);
+    elementChildren(parent).push(descriptor);
+  } else {
+    alpsChildren(profile.alpsNode).push(descriptor);
+  }
+  writeXmlProfile(profile);
+  return { id: input.id, createdChildren, warnings };
+}
+
+export function setXmlDescriptorTags(profilePath: string, input: SetTagsInput): SetTagsResult {
+  if (!input.add?.length && !input.remove?.length) throw new Error("At least one of add or remove is required");
+  const profile = loadXmlProfile(profilePath);
+  const descriptor = findXmlDescriptorById(profile.alpsNode, input.id);
+  if (!descriptor) throw new Error(`Descriptor not found: ${input.id}`);
+
+  const existing = [...new Set((getAttr(descriptor, "tag") || "").split(/\s+/).filter(Boolean))];
+  const removeSet = new Set(input.remove || []);
+  const removed = existing.filter((tag) => removeSet.has(tag));
+  const tags = existing.filter((tag) => !removeSet.has(tag));
+  const added: string[] = [];
+  for (const tag of input.add || []) {
+    if (!tags.includes(tag) && !added.includes(tag)) added.push(tag);
+  }
+  tags.push(...added);
+  if (tags.length === 0) deleteAttr(descriptor, "tag"); else setAttr(descriptor, "tag", tags.join(" "));
+  writeXmlProfile(profile);
+  return { id: input.id, tags, added, removed };
+}
+
+export function renameXmlDescriptor(profilePath: string, oldId: string, newId: string): RenameResult {
+  const profile = loadXmlProfile(profilePath);
+  const target = findXmlDescriptorById(profile.alpsNode, oldId);
+  if (!target) throw new Error(`Descriptor not found: ${oldId}`);
+  if (findXmlDescriptorById(profile.alpsNode, newId)) throw new Error(`Descriptor already exists: ${newId}`);
+
+  setAttr(target, "id", newId);
+  let referencesUpdated = 0;
+  walkXmlDescriptors(profile.alpsNode, (descriptor) => {
+    if (getAttr(descriptor, "href") === `#${oldId}`) { setAttr(descriptor, "href", `#${newId}`); referencesUpdated++; }
+    if (getAttr(descriptor, "rt") === `#${oldId}`) { setAttr(descriptor, "rt", `#${newId}`); referencesUpdated++; }
+  });
+  const result: RenameResult = { id: newId, previousId: oldId, referencesUpdated };
+  const docFile = directChildElement(target, "doc") ? getAttr(directChildElement(target, "doc")!, "href") : undefined;
+  if (docFile) result.docFile = docFile;
+  writeXmlProfile(profile);
+  return result;
+}
+
+export function parseXmlPreserveOrder(content: string): XmlNode[] {
+  const validation = XMLValidator.validate(content) as true | { err?: { msg?: string; line?: number; col?: number } };
+  if (validation !== true) {
+    const err = validation.err;
+    const location = err?.line !== undefined && err?.col !== undefined ? ` (line ${err.line}, col ${err.col})` : "";
+    throw new Error(`Invalid XML format: ${err?.msg || "Malformed XML"}${location}`);
+  }
+  try {
+    const parsed = new XMLParser(XML_OPTIONS).parse(content);
+    if (!Array.isArray(parsed)) throw new Error("Expected preserveOrder XML tree");
+    return parsed as XmlNode[];
+  } catch (e) {
+    throw new Error(`Invalid XML format: ${(e as Error).message}`);
+  }
+}
+
+function loadXmlProfile(profilePath: string): LoadedXmlProfile {
+  const absPath = path.resolve(profilePath);
+  if (!fs.existsSync(absPath)) throw new Error(`Profile file not found: ${profilePath}`);
+  const tree = parseXmlPreserveOrder(fs.readFileSync(absPath, "utf-8"));
+  const alpsNode = tree.find((node) => elementName(node) === "alps");
+  if (!alpsNode) throw new Error("No alps element found in XML");
+  assertSupportedWritableStructure(alpsNode);
+  return { absPath, baseDir: path.dirname(absPath), tree, alpsNode };
+}
+function writeXmlProfile(profile: LoadedXmlProfile): void { fs.writeFileSync(profile.absPath, serializeXml(profile.tree), "utf-8"); }
+export function serializeXml(tree: XmlNode[]): string {
+  const xml = new XMLBuilder({ ...XML_OPTIONS, format: true }).build(tree).replace(/^\n/, "");
+  return xml.endsWith("\n") ? xml : `${xml}\n`;
+}
+function assertSupportedWritableStructure(alpsNode: XmlNode): void {
+  if (elementChildren(alpsNode).some((child) => elementName(child) === TEXT || elementName(child) === CDATA)) {
+    throw new Error("Unsupported XML structure: alps contains mixed text content");
+  }
+  walkXmlDescriptors(alpsNode, (descriptor) => {
+    const id = getAttr(descriptor, "id") || "(without id)";
+    for (const child of elementChildren(descriptor)) {
+      const name = elementName(child);
+      if (name === TEXT || name === CDATA) throw new Error(`Unsupported XML structure: descriptor "${id}" contains mixed text content`);
+      if (name === "doc") assertSupportedDocNode(child, id);
+    }
+  });
+}
+function assertSupportedDocNode(docNode: XmlNode, descriptorId: string): void {
+  if (elementChildren(docNode).some((child) => {
+    const name = elementName(child);
+    return name !== TEXT && name !== CDATA && name !== COMMENT;
+  })) throw new Error(`Unsupported XML structure: doc for descriptor "${descriptorId}" contains mixed content`);
+}
+function findXmlDescriptorById(container: XmlNode, id: string): XmlNode | null {
+  let found: XmlNode | null = null;
+  walkXmlDescriptors(container, (descriptor) => { if (!found && getAttr(descriptor, "id") === id) found = descriptor; });
+  return found;
+}
+function walkXmlDescriptors(container: XmlNode, visit: (descriptor: XmlNode) => void): void {
+  for (const child of elementChildren(container)) {
+    if (elementName(child) !== "descriptor") continue;
+    visit(child);
+    walkXmlDescriptors(child, visit);
+  }
+}
+function alpsChildren(alpsNode: XmlNode): XmlNode[] { return elementChildren(alpsNode); }
+function directChildElement(node: XmlNode, name: string): XmlNode | undefined { return elementChildren(node).find((child) => elementName(child) === name); }
+function insertDocNode(descriptor: XmlNode): XmlNode {
+  const docNode = makeElement("doc", []);
+  const children = elementChildren(descriptor);
+  const index = children.findIndex((child) => elementName(child) === "descriptor");
+  if (index === -1) children.push(docNode); else children.splice(index, 0, docNode);
+  return docNode;
+}
+function elementName(node: XmlNode): string | undefined { return Object.keys(node).find((key) => key !== ATTRS); }
+function elementChildren(node: XmlNode): XmlNode[] {
+  const name = elementName(node);
+  if (!name) throw new Error("Invalid XML structure: element without a name");
+  const children = node[name];
+  return Array.isArray(children) ? children as XmlNode[] : [];
+}
+function setElementChildren(node: XmlNode, children: XmlNode[]): void {
+  const name = elementName(node);
+  if (!name) throw new Error("Invalid XML structure: element without a name");
+  node[name] = children;
+}
+function makeElement(name: string, children: XmlNode[], attrs?: XmlAttrs): XmlNode {
+  const node: XmlNode = { [name]: children };
+  if (attrs && Object.keys(attrs).length > 0) node[ATTRS] = attrs;
+  return node;
+}
+function textNode(text: string): XmlNode { return { [TEXT]: text }; }
+function attrsOf(node: XmlNode, create = false): XmlAttrs | undefined {
+  const attrs = node[ATTRS];
+  if (attrs && typeof attrs === "object" && !Array.isArray(attrs)) return attrs as XmlAttrs;
+  if (!create) return undefined;
+  const next: XmlAttrs = {};
+  node[ATTRS] = next;
+  return next;
+}
+function getAttr(node: XmlNode, name: string): string | undefined {
+  const value = attrsOf(node)?.[`${ATTR_PREFIX}${name}`];
+  return value === undefined ? undefined : String(value);
+}
+function setAttr(node: XmlNode, name: string, value: string): void { attrsOf(node, true)![`${ATTR_PREFIX}${name}`] = value; }
+function deleteAttr(node: XmlNode, name: string): void {
+  const attrs = attrsOf(node);
+  if (!attrs) return;
+  delete attrs[`${ATTR_PREFIX}${name}`];
+  if (Object.keys(attrs).length === 0) delete node[ATTRS];
+}
+function setElementAttrs(node: XmlNode, attrs: XmlAttrs): void { if (Object.keys(attrs).length === 0) delete node[ATTRS]; else node[ATTRS] = attrs; }
+function orderedAttrs(entries: Array<[string, string | undefined]>): XmlAttrs {
+  const attrs: XmlAttrs = {};
+  for (const [name, value] of entries) if (value !== undefined) attrs[`${ATTR_PREFIX}${name}`] = value;
+  return attrs;
+}

--- a/packages/mcp/src/xml-store.ts
+++ b/packages/mcp/src/xml-store.ts
@@ -62,7 +62,7 @@ export function addXmlDescriptor(profilePath: string, input: AddDescriptorInput)
     throw new Error(`Descriptor already exists: ${input.id} (use alps_set_doc to update its documentation)`);
   }
   const warnings: string[] = [];
-  const attrs: Array<[string, string | undefined]> = [["id", input.id]];
+  const attrs: Array<[string, string]> = [["id", input.id]];
   if (input.type && input.type !== "semantic") attrs.push(["type", input.type]);
   if (input.title) attrs.push(["title", input.title]);
   if (input.rt) {
@@ -140,13 +140,20 @@ export function parseXmlPreserveOrder(content: string): XmlNode[] {
   if (validation !== true) {
     const err = validation.err;
     const location = err?.line !== undefined && err?.col !== undefined ? ` (line ${err.line}, col ${err.col})` : "";
-    throw new Error(`Invalid XML format: ${err?.msg || "Malformed XML"}${location}`);
+    /* istanbul ignore else -- XMLValidator always supplies an error message */
+    if (err?.msg) {
+      throw new Error(`Invalid XML format: ${err.msg}${location}`);
+    }
+    /* istanbul ignore next -- XMLValidator always supplies an error message */
+    throw new Error(`Invalid XML format: Malformed XML${location}`);
   }
   try {
     const parsed = new XMLParser(XML_OPTIONS).parse(content);
+    /* istanbul ignore next -- XMLParser preserveOrder returns arrays for valid XML */
     if (!Array.isArray(parsed)) throw new Error("Expected preserveOrder XML tree");
     return parsed as XmlNode[];
   } catch (e) {
+    /* istanbul ignore next -- XMLValidator catches malformed XML before parser exceptions */
     throw new Error(`Invalid XML format: ${(e as Error).message}`);
   }
 }
@@ -163,6 +170,7 @@ function loadXmlProfile(profilePath: string): LoadedXmlProfile {
 function writeXmlProfile(profile: LoadedXmlProfile): void { fs.writeFileSync(profile.absPath, serializeXml(profile.tree), "utf-8"); }
 export function serializeXml(tree: XmlNode[]): string {
   const xml = new XMLBuilder({ ...XML_OPTIONS, format: true }).build(tree).replace(/^\n/, "");
+  /* istanbul ignore next -- XMLBuilder currently omits trailing newline; keep output idempotent if that changes */
   return xml.endsWith("\n") ? xml : `${xml}\n`;
 }
 function assertSupportedWritableStructure(alpsNode: XmlNode): void {
@@ -208,12 +216,15 @@ function insertDocNode(descriptor: XmlNode): XmlNode {
 function elementName(node: XmlNode): string | undefined { return Object.keys(node).find((key) => key !== ATTRS); }
 function elementChildren(node: XmlNode): XmlNode[] {
   const name = elementName(node);
+  /* istanbul ignore next -- all callers pass parsed or constructed element nodes */
   if (!name) throw new Error("Invalid XML structure: element without a name");
   const children = node[name];
+  /* istanbul ignore next -- parsed and constructed element nodes store children arrays */
   return Array.isArray(children) ? children as XmlNode[] : [];
 }
 function setElementChildren(node: XmlNode, children: XmlNode[]): void {
   const name = elementName(node);
+  /* istanbul ignore next -- all callers pass parsed or constructed element nodes */
   if (!name) throw new Error("Invalid XML structure: element without a name");
   node[name] = children;
 }
@@ -226,9 +237,13 @@ function textNode(text: string): XmlNode { return { [TEXT]: text }; }
 function attrsOf(node: XmlNode, create = false): XmlAttrs | undefined {
   const attrs = node[ATTRS];
   if (attrs && typeof attrs === "object" && !Array.isArray(attrs)) return attrs as XmlAttrs;
+  /* istanbul ignore else -- setAttr is only used on descriptor nodes that already have attrs */
   if (!create) return undefined;
+  /* istanbul ignore next -- setAttr is only used on descriptor nodes that already have attrs */
   const next: XmlAttrs = {};
+  /* istanbul ignore next -- setAttr is only used on descriptor nodes that already have attrs */
   node[ATTRS] = next;
+  /* istanbul ignore next -- setAttr is only used on descriptor nodes that already have attrs */
   return next;
 }
 function getAttr(node: XmlNode, name: string): string | undefined {
@@ -243,8 +258,8 @@ function deleteAttr(node: XmlNode, name: string): void {
   if (Object.keys(attrs).length === 0) delete node[ATTRS];
 }
 function setElementAttrs(node: XmlNode, attrs: XmlAttrs): void { if (Object.keys(attrs).length === 0) delete node[ATTRS]; else node[ATTRS] = attrs; }
-function orderedAttrs(entries: Array<[string, string | undefined]>): XmlAttrs {
+function orderedAttrs(entries: Array<[string, string]>): XmlAttrs {
   const attrs: XmlAttrs = {};
-  for (const [name, value] of entries) if (value !== undefined) attrs[`${ATTR_PREFIX}${name}`] = value;
+  for (const [name, value] of entries) attrs[`${ATTR_PREFIX}${name}`] = value;
   return attrs;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.24.3(zod@4.1.13)
+      fast-xml-parser:
+        specifier: ^4.5.0
+        version: 4.5.3
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0


### PR DESCRIPTION
alps_set_doc / alps_add_descriptor / alps_set_tags / alps_rename now support XML profiles. 162 tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editing support for ALPS profiles in XML alongside JSON; core ALPS tools now work with both formats.
* **Documentation**
  * README and tool descriptions updated to describe JSON/XML support and XML write behavior/limits.
* **Tests**
  * Added comprehensive XML-focused tests exercising descriptor/doc edits, renames, tags, validation, and security cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->